### PR TITLE
Fix critical sudo_logsrvd compatibility issues

### DIFF
--- a/internal/connection/handler_test.go
+++ b/internal/connection/handler_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // mockSessionHandler is a mock implementation of the SessionHandler interface for testing.
@@ -182,11 +184,11 @@ func TestConnectionHandler(t *testing.T) {
 		sessionClosed := make(chan bool, 1)
 
 		// Override the session factory on the handler instance to return our mock
-		handler.sessionFactories.newLocalStorageSession = func(logID string, acceptMsg *pb.AcceptMessage, cfg *config.LocalStorageConfig) (SessionHandler, error) {
+		handler.sessionFactories.newLocalStorageSession = func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.LocalStorageConfig) (SessionHandler, error) {
 			return &mockSessionHandler{
 				t: t,
 				HandleClientFn: func(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
-					return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: logID}}, nil
+					return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: sessionUUID.String()}}, nil
 				},
 				CloseFn: func() error {
 					sessionClosed <- true

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Helper to create a standard AcceptMessage for tests
@@ -168,11 +170,11 @@ func TestRelaySession_CacheAndFlush(t *testing.T) {
 		UpstreamHost:         mockServer.Addr(),
 	}
 
-	logID := "relay-test-01"
+	sessionUUID := uuid.MustParse("a1b2c3d4-e5f6-4a1b-8c3d-9e8f7a6b5c4d")
 	acceptMsg := createTestAcceptMessage()
 
 	// 3. Create a new relay session
-	session, err := NewSession(logID, acceptMsg, relayCfg)
+	session, err := NewSession(sessionUUID, acceptMsg, relayCfg)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -241,8 +243,8 @@ func TestRelaySession_CacheAndFlush(t *testing.T) {
 		t.Errorf("Expected last flushed message to be ExitMsg, but it was %T", allMsgs[3].Type)
 	}
 
-	// 8. Verify the cache file was deleted
-	cacheFilePath := filepath.Join(tmpDir, logID+".log")
+	// 8. Verify the cache file was deleted (uses UUID string for filename)
+	cacheFilePath := filepath.Join(tmpDir, sessionUUID.String()+".log")
 	if _, err := os.Stat(cacheFilePath); !os.IsNotExist(err) {
 		t.Errorf("Expected cache file %s to be deleted after successful flush, but it still exists", cacheFilePath)
 	}

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -2,6 +2,7 @@
 package storage
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +12,8 @@ import (
 	pb "sudosrv/pkg/sudosrv_proto"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Helper to create a standard AcceptMessage for tests
@@ -39,7 +42,7 @@ func createTestAcceptMessage() *pb.AcceptMessage {
 }
 
 func TestStorageSession(t *testing.T) {
-	logID := "a1b2c3d4-e5f6-4a1b-8c3d-9e8f7a6b5c4d"
+	sessionUUID := uuid.MustParse("a1b2c3d4-e5f6-4a1b-8c3d-9e8f7a6b5c4d")
 
 	t.Run("SessionInitializationAndFinalizationWithIologDir", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -51,7 +54,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -63,9 +66,12 @@ func TestStorageSession(t *testing.T) {
 			t.Fatalf("HandleClientMessage(Accept) failed: %v", err)
 		}
 
-		// Check for correct server response (log_id)
-		if serverResponse.GetLogId() != logID {
-			t.Errorf("Expected server response to be log_id '%s', got '%s'", logID, serverResponse.GetLogId())
+		// Check for correct server response (log_id should be base64-encoded)
+		expectedRelPath := "testuser/000001"
+		idBytes := append(sessionUUID[:], []byte(expectedRelPath)...)
+		expectedLogID := base64.StdEncoding.EncodeToString(idBytes)
+		if serverResponse.GetLogId() != expectedLogID {
+			t.Errorf("Expected server response to be log_id '%s', got '%s'", expectedLogID, serverResponse.GetLogId())
 		}
 
 		// Send Exit message to finalize
@@ -120,7 +126,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -177,7 +183,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -270,7 +276,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -340,7 +346,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -400,7 +406,7 @@ func TestStorageSession(t *testing.T) {
 			LogDirectory: "/invalid/path/that/does/not/exist",
 		}
 
-		_, err := NewSession(logID, createTestAcceptMessage(), invalidCfg)
+		_, err := NewSession(sessionUUID, createTestAcceptMessage(), invalidCfg)
 		if err == nil {
 			t.Fatal("NewSession() should have failed with invalid directory")
 		}
@@ -413,7 +419,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -444,7 +450,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}
@@ -483,7 +489,7 @@ func TestStorageSession(t *testing.T) {
 			FilePermissions: 0644,
 		}
 
-		session, err := NewSession(logID, createTestAcceptMessage(), storageCfg)
+		session, err := NewSession(sessionUUID, createTestAcceptMessage(), storageCfg)
 		if err != nil {
 			t.Fatalf("NewSession() failed: %v", err)
 		}


### PR DESCRIPTION
## 💪 What

- Adds path traversal protection to escape sequence expansion — `sanitizePathComponent()` strips `/` from user-controlled values (matching C `strlcpy_no_slash`), `containsDotDot()` rejects `..` components (matching C `contains_dot_dot()`)
- Fixes log ID format to `base64(UUID_bytes + relative_path)`, matching C `gen_log_id()` in `logsrvd.c`
- Adds CommandSuspend signal validation against the 5 allowed signals (STOP, TSTP, CONT, TTIN, TTOU), matching C `handle_suspend()` validation
- Adds UUID file creation in session directories for RestartMessage compatibility and sudoreplay tooling (matching C `iolog_store_uuid`)
- Sets `ServerHello.Subcommands = true` to advertise sub-command support to clients
- Updates session factory signatures from `string` to `uuid.UUID` throughout handler and relay layers
- Updates all tests to use `uuid.UUID` and validate base64-encoded log IDs

## 🤔 Why

- Path traversal via crafted `submituser`, `hostname`, or `command` fields in AcceptMessage could allow writing session logs outside the intended directory — this is a security fix
- Log ID mismatch with C format would break interoperability with upstream `sudo_logsrvd` servers in relay mode and any tooling that parses log IDs
- Accepting arbitrary signal names in CommandSuspend violates the sudo protocol spec and could produce corrupt timing files
- Missing UUID file breaks `RestartMessage` support and compatibility with `sudoreplay` tooling
- Missing `Subcommands` advertisement means clients won't send sub-command metadata

## 👀 Usage

No configuration changes needed. Existing relay cache files using the old log ID format will still flush correctly since cache files use UUID strings for naming (not log IDs).

## 👩‍🔬 How to validate

- Start a local storage session with escape sequences in `iolog_dir` containing a crafted `submituser` with `/../../` — verify the session is rejected or the path is sanitized
- Check session directories now contain a `uuid` file with the session UUID
- Send a `CommandSuspend` with an invalid signal name (e.g., "KILL") — verify it returns an error
- Connect a sudo client and verify the `ServerHello` response includes `subcommands: true`
- In relay mode, verify the log ID sent to upstream matches `base64(UUID + path)` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches security-sensitive filesystem path construction and changes the `log_id` format used by clients/upstreams, which may affect interoperability and log lookup despite added protections and updated tests.
> 
> **Overview**
> Fixes multiple sudo_logsrvd compatibility and security issues across local storage, relay, and connection handling.
> 
> `storage.NewSession` now generates `log_id` in C sudo_logsrvd format (`base64(UUID_bytes + relative_path)`), writes a `uuid` file into each session directory, sanitizes user-controlled escape expansions to strip `/`, rejects constructed paths containing `..`, and validates `CommandSuspend` signals against the allowed set. `relay.NewSession` now uses the same UUID-driven `log_id` semantics (base64 UUID bytes) while keeping cache filenames as UUID strings.
> 
> The connection handler now advertises `ServerHello.Subcommands = true` and session factories are updated end-to-end to pass `uuid.UUID` instead of a string; tests are updated accordingly (including asserting base64 `log_id` values and UUID-based cache filenames).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4581107574646bb5a09574f61089fc2538f2317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->