### PR TITLE
Implement HIGH priority sudo_logsrvd compatibility fixes

### DIFF
--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -4,9 +4,12 @@ package connection
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"sudosrv/internal/config"
 	"sudosrv/internal/metrics"
 	"sudosrv/internal/protocol"
@@ -36,6 +39,7 @@ type Handler struct {
 	sessionFactories struct {
 		newLocalStorageSession func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
 		newRelaySession        func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig) (SessionHandler, error)
+		newLocalRestartSession func(restartMsg *pb.RestartMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
 	}
 }
 
@@ -68,6 +72,9 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 	}
 	h.sessionFactories.newRelaySession = func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, relayCfg *config.RelayConfig) (SessionHandler, error) {
 		return relay.NewSession(sessionUUID, acceptMsg, relayCfg)
+	}
+	h.sessionFactories.newLocalRestartSession = func(restartMsg *pb.RestartMessage, localCfg *config.LocalStorageConfig) (SessionHandler, error) {
+		return storage.NewRestartSession(restartMsg, localCfg)
 	}
 	return h
 }
@@ -163,11 +170,25 @@ func (h *Handler) processMessage(clientMsg *pb.ClientMessage) (*pb.ServerMessage
 		slog.Info("Received AcceptMessage", "expect_io", event.AcceptMsg.ExpectIobufs, "remote_addr", h.conn.RemoteAddr())
 		return h.handleAccept(event.AcceptMsg)
 
+	case *pb.ClientMessage_AlertMsg:
+		slog.Info("Received pre-session AlertMessage",
+			"reason", event.AlertMsg.GetReason(),
+			"remote_addr", h.conn.RemoteAddr())
+		if alertTime := event.AlertMsg.GetAlertTime(); alertTime != nil {
+			slog.Info("Alert details", "alert_time", time.Unix(alertTime.TvSec, int64(alertTime.TvNsec)).UTC())
+		}
+		for _, info := range event.AlertMsg.GetInfoMsgs() {
+			slog.Info("Alert info", "key", info.GetKey(), "value", info.GetStrval())
+		}
+		return nil, nil // No response needed for alerts
+
 	case *pb.ClientMessage_RejectMsg:
 		slog.Info("Received RejectMessage", "reason", event.RejectMsg.Reason, "remote_addr", h.conn.RemoteAddr())
-		// For now, we just log this and take no further action.
-		// A more advanced server might write an event log.
-		return nil, nil // No response needed
+		return h.handleReject(event.RejectMsg)
+
+	case *pb.ClientMessage_RestartMsg:
+		slog.Info("Received RestartMessage", "log_id", event.RestartMsg.GetLogId(), "remote_addr", h.conn.RemoteAddr())
+		return h.handleRestart(event.RestartMsg)
 
 	case *pb.ClientMessage_ExitMsg:
 		// This can happen if a command is run without I/O logging.
@@ -275,6 +296,91 @@ func (h *Handler) setOrUpdateInfoMessage(acceptMsg *pb.AcceptMessage, key, value
 		Key:   key,
 		Value: &pb.InfoMessage_Strval{Strval: value},
 	})
+}
+
+// handleReject logs a rejected command event. In local mode, it persists a
+// log.json event record to disk. In relay mode, it only logs via slog.
+func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, error) {
+	if h.config.Server.Mode != "local" {
+		slog.Info("Reject event in non-local mode, logging only", "reason", rejectMsg.GetReason())
+		return nil, nil
+	}
+
+	// Generate a UUID-based path for the reject event log
+	rejectUUID := uuid.New()
+	uuidStr := rejectUUID.String()
+	sessID := uuidStr[:6]
+	rejectDir := filepath.Join(h.config.LocalStorage.LogDirectory, sessID[:2], sessID[2:4], sessID[4:6])
+
+	if err := os.MkdirAll(rejectDir, os.FileMode(h.config.LocalStorage.DirPermissions)); err != nil {
+		slog.Error("Failed to create reject event directory", "error", err, "path", rejectDir)
+		return nil, nil // Non-fatal
+	}
+
+	// Build the event record
+	eventRecord := map[string]interface{}{
+		"event_type": "reject",
+		"reason":     rejectMsg.GetReason(),
+	}
+	if st := rejectMsg.GetSubmitTime(); st != nil {
+		eventRecord["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
+	}
+
+	// Extract info messages
+	infoMap := make(map[string]interface{})
+	for _, info := range rejectMsg.GetInfoMsgs() {
+		key := info.GetKey()
+		switch v := info.Value.(type) {
+		case *pb.InfoMessage_Strval:
+			infoMap[key] = v.Strval
+		case *pb.InfoMessage_Numval:
+			infoMap[key] = v.Numval
+		case *pb.InfoMessage_Strlistval:
+			infoMap[key] = v.Strlistval.GetStrings()
+		}
+	}
+	if len(infoMap) > 0 {
+		for k, v := range infoMap {
+			eventRecord[k] = v
+		}
+	}
+
+	data, err := json.MarshalIndent(eventRecord, "", "  ")
+	if err != nil {
+		slog.Error("Failed to marshal reject event", "error", err)
+		return nil, nil // Non-fatal
+	}
+
+	logJSONPath := filepath.Join(rejectDir, "log.json")
+	if err := os.WriteFile(logJSONPath, data, os.FileMode(h.config.LocalStorage.FilePermissions)); err != nil {
+		slog.Error("Failed to write reject event log", "error", err, "path", logJSONPath)
+		return nil, nil // Non-fatal
+	}
+
+	slog.Info("Wrote reject event log", "path", logJSONPath, "reason", rejectMsg.GetReason())
+	return nil, nil
+}
+
+// handleRestart resumes an existing session from a RestartMessage.
+func (h *Handler) handleRestart(restartMsg *pb.RestartMessage) (*pb.ServerMessage, error) {
+	if h.config.Server.Mode != "local" {
+		return nil, fmt.Errorf("restart not supported in %s mode", h.config.Server.Mode)
+	}
+
+	session, err := h.sessionFactories.newLocalRestartSession(restartMsg, &h.config.LocalStorage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create restart session: %w", err)
+	}
+
+	h.session = session
+	h.logID = restartMsg.GetLogId()
+	metrics.Global.IncrementSessions()
+	metrics.Global.IncrementLocalSessions()
+	slog.Info("Resumed local storage session via restart",
+		"log_id", h.logID,
+		"total_sessions", metrics.Global.GetTotalSessions())
+
+	return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: restartMsg.GetLogId()}}, nil
 }
 
 // handleAccept sets up a session for an accepted command.

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -341,6 +341,10 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 	}
 	if len(infoMap) > 0 {
 		for k, v := range infoMap {
+			// Preserve authoritative fields already set by the server.
+			if _, exists := eventRecord[k]; exists {
+				continue
+			}
 			eventRecord[k] = v
 		}
 	}

--- a/internal/connection/handler_test.go
+++ b/internal/connection/handler_test.go
@@ -523,6 +523,9 @@ func TestPreSessionRejectEventLogging(t *testing.T) {
 				InfoMsgs: []*pb.InfoMessage{
 					{Key: "command", Value: &pb.InfoMessage_Strval{Strval: "/usr/sbin/reboot"}},
 					{Key: "submituser", Value: &pb.InfoMessage_Strval{Strval: "eviluser"}},
+					{Key: "event_type", Value: &pb.InfoMessage_Strval{Strval: "accept"}},
+					{Key: "reason", Value: &pb.InfoMessage_Strval{Strval: "attacker override"}},
+					{Key: "submit_time", Value: &pb.InfoMessage_Strval{Strval: "attacker time"}},
 				},
 			},
 		},
@@ -566,6 +569,13 @@ func TestPreSessionRejectEventLogging(t *testing.T) {
 			}
 			if eventRecord["reason"] != "command not allowed" {
 				t.Errorf("Expected reason 'command not allowed', got '%v'", eventRecord["reason"])
+			}
+			expectedSubmitTime := time.Unix(1700000000, 0).UTC().Format(time.RFC3339Nano)
+			if eventRecord["submit_time"] != expectedSubmitTime {
+				t.Errorf("Expected submit_time '%s', got '%v'", expectedSubmitTime, eventRecord["submit_time"])
+			}
+			if eventRecord["command"] != "/usr/sbin/reboot" {
+				t.Errorf("Expected command '/usr/sbin/reboot', got '%v'", eventRecord["command"])
 			}
 		}
 		return nil

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -676,6 +676,10 @@ func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.Serve
 	}
 	if len(infoMap) > 0 {
 		for k, v := range infoMap {
+			// Preserve authoritative fields already set by the server.
+			if _, exists := entry[k]; exists {
+				continue
+			}
 			entry[k] = v
 		}
 	}
@@ -718,6 +722,10 @@ func (s *Session) handleSubCommandReject(rejectMsg *pb.RejectMessage) (*pb.Serve
 	}
 	if len(infoMap) > 0 {
 		for k, v := range infoMap {
+			// Preserve authoritative fields already set by the server.
+			if _, exists := entry[k]; exists {
+				continue
+			}
 			entry[k] = v
 		}
 	}

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -760,6 +760,9 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 	}
 
 	// Path safety check
+	if filepath.IsAbs(relativePath) || strings.HasPrefix(filepath.ToSlash(relativePath), "/") || filepath.VolumeName(relativePath) != "" {
+		return nil, fmt.Errorf("absolute path detected in log_id path: %s", relativePath)
+	}
 	if containsDotDot(relativePath) {
 		return nil, fmt.Errorf("path traversal detected in log_id path: %s", relativePath)
 	}

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -623,6 +623,8 @@ func TestStorageSession(t *testing.T) {
 					SubmitTime: &pb.TimeSpec{TvSec: 1700000100, TvNsec: 0},
 					InfoMsgs: []*pb.InfoMessage{
 						{Key: "command", Value: &pb.InfoMessage_Strval{Strval: "/usr/bin/cat /etc/passwd"}},
+						{Key: "event_type", Value: &pb.InfoMessage_Strval{Strval: "reject"}},
+						{Key: "submit_time", Value: &pb.InfoMessage_Strval{Strval: "attacker time"}},
 					},
 				},
 			},
@@ -655,6 +657,13 @@ func TestStorageSession(t *testing.T) {
 		if subCmd["event_type"] != "accept" {
 			t.Errorf("Expected event_type 'accept', got '%v'", subCmd["event_type"])
 		}
+		expectedSubmitTime := time.Unix(1700000100, 0).UTC().Format(time.RFC3339Nano)
+		if subCmd["submit_time"] != expectedSubmitTime {
+			t.Errorf("Expected submit_time '%s', got '%v'", expectedSubmitTime, subCmd["submit_time"])
+		}
+		if subCmd["command"] != "/usr/bin/cat /etc/passwd" {
+			t.Errorf("Expected command '/usr/bin/cat /etc/passwd', got '%v'", subCmd["command"])
+		}
 	})
 
 	t.Run("SubCommandReject", func(t *testing.T) {
@@ -683,6 +692,9 @@ func TestStorageSession(t *testing.T) {
 					Reason:     "policy denied sub-command",
 					InfoMsgs: []*pb.InfoMessage{
 						{Key: "command", Value: &pb.InfoMessage_Strval{Strval: "/usr/sbin/visudo"}},
+						{Key: "event_type", Value: &pb.InfoMessage_Strval{Strval: "accept"}},
+						{Key: "reason", Value: &pb.InfoMessage_Strval{Strval: "attacker override"}},
+						{Key: "submit_time", Value: &pb.InfoMessage_Strval{Strval: "attacker time"}},
 					},
 				},
 			},
@@ -714,6 +726,13 @@ func TestStorageSession(t *testing.T) {
 		}
 		if subCmd["reason"] != "policy denied sub-command" {
 			t.Errorf("Expected reason 'policy denied sub-command', got '%v'", subCmd["reason"])
+		}
+		expectedSubmitTime := time.Unix(1700000200, 0).UTC().Format(time.RFC3339Nano)
+		if subCmd["submit_time"] != expectedSubmitTime {
+			t.Errorf("Expected submit_time '%s', got '%v'", expectedSubmitTime, subCmd["submit_time"])
+		}
+		if subCmd["command"] != "/usr/sbin/visudo" {
+			t.Errorf("Expected command '/usr/sbin/visudo', got '%v'", subCmd["command"])
 		}
 	})
 

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -1052,10 +1052,6 @@ func TestNewRestartSession(t *testing.T) {
 		if !filepath.IsAbs(decodedPath) {
 			t.Fatalf("test setup failed: decoded path is not absolute: %q", decodedPath)
 		}
-		joinedPath := filepath.Join(logRoot, decodedPath)
-		if joinedPath != decodedPath {
-			t.Fatalf("test setup failed: expected absolute path to override log root in filepath.Join, got %q", joinedPath)
-		}
 		restartMsg := &pb.RestartMessage{
 			LogId:       absolutePathLogID,
 			ResumePoint: &pb.TimeSpec{TvSec: 1, TvNsec: 0},
@@ -1086,19 +1082,14 @@ func TestPathWithinBase(t *testing.T) {
 		}
 	})
 
-	t.Run("AbsoluteJoinEscapeIsRejected", func(t *testing.T) {
+	t.Run("AbsoluteTargetOutsideRootIsRejected", func(t *testing.T) {
 		outsideRoot := t.TempDir()
-		joinedPath := filepath.Join(logRoot, outsideRoot)
-		if joinedPath != outsideRoot {
-			t.Fatalf("test setup failed: expected absolute path to override base join, got %q", joinedPath)
-		}
-
-		within, err := pathWithinBase(logRoot, joinedPath)
+		within, err := pathWithinBase(logRoot, outsideRoot)
 		if err != nil {
 			t.Fatalf("pathWithinBase() returned unexpected error: %v", err)
 		}
 		if within {
-			t.Fatalf("expected %q to be rejected as outside %q", joinedPath, logRoot)
+			t.Fatalf("expected %q to be rejected as outside %q", outsideRoot, logRoot)
 		}
 	})
 


### PR DESCRIPTION
## 💪 What

- Adds AlertMessage handling — pre-session alerts are logged via slog; in-session alerts are persisted to the `alerts` array in `log.json`
- Adds RejectMessage event logging — rejected commands in local mode now write a `log.json` event record to disk (non-fatal on errors)
- Adds sub-command support — in-session AcceptMsg and RejectMsg are recorded to the `sub_commands` array in `log.json`, with sub-commands sharing the parent session's `log_id` (matching C `sudo_logsrvd` behavior)
- Adds RestartMessage session resume — decodes log_id back to UUID + path, validates UUID match, timing file writability, and path safety, then reopens all files in append mode with `resume_point` restoration
- Adds `Subcommands: true` to ServerHello (already in first commit, noted for completeness)

## 🤔 Why

- These are the HIGH priority gaps identified from a comparison of the C `sudo_logsrvd` with the Go reimplementation
- The CRITICAL fixes (path traversal, log ID format, signal validation, UUID file) were merged in PR #2 — this continues closing the compatibility gap
- Without AlertMessage/RejectMessage handling, security policy alerts and command denials are silently dropped
- Without sub-command support, `sudo` clients that send sub-commands after `Subcommands: true` hit protocol errors
- Without RestartMessage, interrupted sessions cannot be resumed, requiring full retransmission

## 👀 Usage

No configuration changes needed — all new message types are handled automatically by the existing protocol state machine.

**Sub-commands**: Already advertised via `Subcommands: true` in ServerHello. When a sudo client sends a subsequent AcceptMsg or RejectMsg within an active session, the server records it under `sub_commands` in `log.json`.

**Restart**: When a sudo client sends a RestartMessage with a valid `log_id`, the server decodes the UUID and path, verifies the session exists and is not completed, and resumes I/O logging from the `resume_point`.

**Reject events**: In local mode, rejected commands now produce a `log.json` file containing `event_type: "reject"`, the reason, and all info messages from the client.

## 👩‍🔬 How to validate

1. **Alert handling**: Start a local-mode server and send a ClientMessage with an AlertMsg payload (both pre-session and in-session). Verify the alert appears in slog output and in the session's `log.json` `alerts` array.

2. **Reject logging**: Send a RejectMessage to a local-mode server. Check that a `log.json` file is created under the log directory with `event_type: "reject"` and the rejection reason.

3. **Sub-commands**: Start a session with `ExpectIobufs: true`, then send a second AcceptMsg. Verify `log.json` contains a `sub_commands` array with `event_type: "accept"` and that the response returns the same `log_id`.

4. **Restart**: Create a session, write some I/O, close without sending ExitMessage. Then send a RestartMessage with the original `log_id` and a `resume_point`. Verify the server returns the same `log_id` and that subsequent I/O data is appended to existing files.

5. **Restart rejection**: Attempt to restart a completed session (one where ExitMessage was sent). Verify the server returns an error about the timing file being read-only.

## 🔗 Related links

- #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core protocol routing and local filesystem log persistence/resume logic, which could impact session lifecycle and log integrity if edge cases are missed.
> 
> **Overview**
> Improves `sudo_logsrvd` protocol compatibility by handling additional client message types and persisting more event metadata in local storage.
> 
> `Handler` now accepts pre-session `AlertMsg` (log-only), persists pre-session `RejectMsg` events to a standalone `log.json` in local mode, and supports `RestartMsg` to resume an existing local log via a new restart session factory.
> 
> Local storage sessions now treat in-session `AlertMsg` as metadata appended to `log.json` (`alerts`), and record in-session sub-command `AcceptMsg`/`RejectMsg` entries under `sub_commands` while returning the same `log_id` for sub-command accepts. Restart support adds `DecodeLogID` + `NewRestartSession` to validate and reopen an existing session directory for append, restoring commit-point state from `resume_point` and rejecting completed/compressed sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 882550d3cd07f60431dc91ec843115421a8bda7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->