### PR TITLE
Throttle commit points, add relay acks, remove log.json hot-path rewrites, add SIGHUP reload

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sudosrv/internal/config"
+	"testing"
+)
+
+func TestServerReload(t *testing.T) {
+	// Create a temporary config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	initialConfig := `server:
+  mode: "local"
+  listen_address: "127.0.0.1:30343"
+  server_operational_log_level: "info"
+local_storage:
+  log_directory: "/tmp/test-logs"
+`
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0644); err != nil {
+		t.Fatalf("Failed to write initial config: %v", err)
+	}
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelInfo)
+
+	srv, err := NewServer(cfg, configPath, logLevel)
+	if err != nil {
+		t.Fatalf("NewServer() failed: %v", err)
+	}
+
+	// Verify initial state
+	if logLevel.Level() != slog.LevelInfo {
+		t.Fatalf("Expected initial log level INFO, got %s", logLevel.Level())
+	}
+
+	t.Run("LogLevelChange", func(t *testing.T) {
+		// Update config file with new log level
+		updatedConfig := `server:
+  mode: "local"
+  listen_address: "127.0.0.1:30343"
+  server_operational_log_level: "debug"
+local_storage:
+  log_directory: "/tmp/test-logs"
+`
+		if err := os.WriteFile(configPath, []byte(updatedConfig), 0644); err != nil {
+			t.Fatalf("Failed to write updated config: %v", err)
+		}
+
+		srv.reload()
+
+		if logLevel.Level() != slog.LevelDebug {
+			t.Errorf("Expected log level DEBUG after reload, got %s", logLevel.Level())
+		}
+	})
+
+	t.Run("InvalidLogLevel", func(t *testing.T) {
+		// Set log level to something known first
+		logLevel.Set(slog.LevelWarn)
+
+		badConfig := `server:
+  mode: "local"
+  listen_address: "127.0.0.1:30343"
+  server_operational_log_level: "invalid_level"
+local_storage:
+  log_directory: "/tmp/test-logs"
+`
+		if err := os.WriteFile(configPath, []byte(badConfig), 0644); err != nil {
+			t.Fatalf("Failed to write bad config: %v", err)
+		}
+
+		srv.reload()
+
+		// Log level should remain unchanged on invalid input
+		if logLevel.Level() != slog.LevelWarn {
+			t.Errorf("Expected log level to remain WARN after invalid reload, got %s", logLevel.Level())
+		}
+	})
+
+	t.Run("MissingConfigFile", func(t *testing.T) {
+		logLevel.Set(slog.LevelError)
+		srv.configPath = filepath.Join(tmpDir, "nonexistent.yaml")
+
+		srv.reload()
+
+		// With the current config.LoadConfig behavior, missing file returns defaults
+		// but log level should still be updated based on the default ("info")
+		if logLevel.Level() != slog.LevelInfo {
+			t.Errorf("Expected log level INFO from defaults after missing config reload, got %s", logLevel.Level())
+		}
+
+		// Restore path
+		srv.configPath = configPath
+	})
+
+	t.Run("ConfigUpdated", func(t *testing.T) {
+		// Verify that new config is picked up
+		newConfig := `server:
+  mode: "local"
+  listen_address: "127.0.0.1:30343"
+  server_operational_log_level: "error"
+  server_id: "TestServer/2.0"
+local_storage:
+  log_directory: "/tmp/test-logs-v2"
+`
+		if err := os.WriteFile(configPath, []byte(newConfig), 0644); err != nil {
+			t.Fatalf("Failed to write new config: %v", err)
+		}
+
+		srv.reload()
+
+		if srv.config.Server.ServerID != "TestServer/2.0" {
+			t.Errorf("Expected server_id 'TestServer/2.0', got '%s'", srv.config.Server.ServerID)
+		}
+		if srv.config.LocalStorage.LogDirectory != "/tmp/test-logs-v2" {
+			t.Errorf("Expected log_directory '/tmp/test-logs-v2', got '%s'", srv.config.LocalStorage.LogDirectory)
+		}
+		if logLevel.Level() != slog.LevelError {
+			t.Errorf("Expected log level ERROR, got %s", logLevel.Level())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Commit point batching (#9)**: Only send CommitPoint every 10s matching C sudo_logsrvd's `ACK_FREQUENCY`; first I/O event always sends one (zero-value `lastCommitTime` guarantee)
- **Relay commit forwarding (#10)**: Relay sessions now generate local commit points for clients using the same 10s throttle interval, so relay clients no longer receive zero commit points
- **SIGHUP config reload (#11)**: Server re-reads config on SIGHUP, dynamically updates log level via `slog.LevelVar`, warns about restart-required changes (listeners, TLS, mode)
- **Remove log.json rewrite overhead (#14)**: `writeIoEntry`, `handleWinsize`, and `handleSuspend` no longer call `updateLogJSON` since they don't modify metadata; calls retained only where metadata actually changes (initialize, finalize, alerts, sub-commands, restarts)

## Files changed

- `internal/storage/session.go` — commit point throttling, removed wasteful `updateLogJSON` calls
- `internal/relay/session.go` — `extractIoDelay` helper, commit point generation for relay clients
- `internal/server/server.go` — `configPath`/`logLevel` fields, `reload()` method, SIGHUP in `Wait()`
- `cmd/sudosrv/main.go` — `slog.LevelVar` for dynamic log level, passes config path to server
- `internal/storage/session_test.go` — `TestCommitPointThrottling`, `TestNoLogJSONRewriteOnIoEvents`
- `internal/relay/session_test.go` — `TestRelayCommitPoints`, `TestRelayCommitPointThrottling`
- `internal/server/server_test.go` — `TestServerReload` (log level change, invalid level, missing config, config update)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `TestCommitPointThrottling` — first event returns commit point, subsequent within 10s return nil, event after interval returns commit point
- [x] `TestNoLogJSONRewriteOnIoEvents` — verifies log.json mtime unchanged after I/O, winsize, and suspend events
- [x] `TestRelayCommitPoints` — relay returns commit points for I/O buffers, nil for non-I/O events
- [x] `TestRelayCommitPointThrottling` — relay throttling matches local storage behavior
- [x] `TestServerReload` — log level changes applied, invalid levels rejected, config pointer updated