### PR TITLE
Add Arch Linux packaging and bump Go version to 1.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LDFLAGS_STRIP = -ldflags="-s -w"
 .DEFAULT_GOAL := help
 
 # Phony targets do not represent files
-.PHONY: all build build-release build-linux-amd64 build-linux-arm64 release-all build-static-linux-amd64 build-static-linux-arm64 release-static-all proto test deps run clean help rpm deb
+.PHONY: all build build-release build-linux-amd64 build-linux-arm64 release-all build-static-linux-amd64 build-static-linux-arm64 release-static-all proto test deps run clean help rpm deb arch
 
 # Build the application for local architecture
 all: build
@@ -162,6 +162,16 @@ deb:
 		echo "Check if dpkg-buildpackage completed successfully"; \
 	fi
 
+# Build Arch Linux package
+arch:
+	@echo "Building Arch Linux package for $(BINARY_NAME) version $(PKG_VERSION)"
+	@if ! command -v makepkg >/dev/null 2>&1; then \
+		echo "Error: makepkg not found. This must be run on Arch Linux."; \
+		echo "  sudo pacman -S base-devel"; \
+		exit 1; \
+	fi
+	./archlinux/build-arch.sh "$(PKG_VERSION)"
+
 # Display help information
 help:
 	@echo "Usage: make [target]"
@@ -183,4 +193,5 @@ help:
 	@echo "  clean                    Remove all compiled binaries and build cache."
 	@echo "  rpm                      Build RPM package for distribution."
 	@echo "  deb                      Build Debian package for distribution."
+	@echo "  arch                     Build Arch Linux package for distribution."
 	@echo "  help                     Display this help message."

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Paul Kilar <pkilar@gmail.com>
+pkgname=sudosrv
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Go-based sudo I/O log server implementing the sudo_logsrv.proto protocol'
+arch=('x86_64' 'aarch64')
+url='https://github.com/pkilar/sudosrv'
+license=('MIT')
+depends=('glibc')
+makedepends=('go>=1.25' 'protobuf')
+optdepends=('sudo: sudo client (>= 1.9.0)')
+backup=('etc/sudosrv/config.yaml'
+        'etc/logrotate.d/sudosrv')
+install=sudosrv.install
+source=("${pkgname}-${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    cd "${pkgname}-${pkgver}"
+
+    # Generate protobuf code
+    protoc \
+        --proto_path=pkg/sudosrv_proto \
+        --go_out=pkg/sudosrv_proto \
+        --go_opt=paths=source_relative \
+        pkg/sudosrv_proto/sudo_logsrv.proto
+
+    # Tidy dependencies
+    go mod tidy
+
+    # Build with stripped symbols
+    export CGO_ENABLED=0
+    go build -ldflags="-s -w" -o sudosrv ./cmd/sudosrv
+}
+
+check() {
+    cd "${pkgname}-${pkgver}"
+    go test -timeout 30s ./...
+}
+
+package() {
+    cd "${pkgname}-${pkgver}"
+
+    # Binary
+    install -Dm0755 sudosrv "${pkgdir}/usr/bin/sudosrv"
+
+    # Configuration
+    install -Dm0644 archlinux/sudosrv.conf "${pkgdir}/etc/sudosrv/config.yaml"
+
+    # Systemd service
+    install -Dm0644 archlinux/sudosrv.service "${pkgdir}/usr/lib/systemd/system/sudosrv.service"
+
+    # Systemd sysusers (creates sudosrv user/group)
+    install -Dm0644 archlinux/sudosrv.sysusers "${pkgdir}/usr/lib/sysusers.d/sudosrv.conf"
+
+    # Systemd tmpfiles (creates log/cache directories)
+    install -Dm0644 archlinux/sudosrv.tmpfiles "${pkgdir}/usr/lib/tmpfiles.d/sudosrv.conf"
+
+    # Logrotate
+    install -Dm0644 archlinux/sudosrv.logrotate "${pkgdir}/etc/logrotate.d/sudosrv"
+}

--- a/archlinux/build-arch.sh
+++ b/archlinux/build-arch.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+# Build Arch Linux package for sudosrv
+# Usage: ./archlinux/build-arch.sh [version]
+
+VERSION=${1:-0.1.0}
+PACKAGE_NAME="sudosrv"
+BUILD_ROOT="$PWD"
+ARCH_DIR="$BUILD_ROOT/archlinux"
+WORK_DIR=$(mktemp -d)
+
+echo "Building Arch Linux package for $PACKAGE_NAME version $VERSION"
+
+# Check for makepkg
+if ! command -v makepkg &> /dev/null; then
+    echo "Error: makepkg not found. This must be run on Arch Linux."
+    echo "Install base-devel: sudo pacman -S base-devel"
+    exit 1
+fi
+
+# Create source tarball
+echo "Creating source tarball..."
+SOURCE_DIR="$WORK_DIR/${PACKAGE_NAME}-${VERSION}"
+mkdir -p "$SOURCE_DIR"
+
+rsync -a \
+    --exclude='.git' \
+    --exclude='rpm/RPMS' \
+    --exclude='rpm/SRPMS' \
+    --exclude='rpm/BUILD' \
+    --exclude='rpm/BUILDROOT' \
+    --exclude='rpm/SOURCES/*.tar.gz' \
+    --exclude='deb/' \
+    --exclude='debian/sudosrv/' \
+    --exclude='debian/.debhelper/' \
+    --exclude='sudosrv' \
+    --exclude='sudosrv-linux-*' \
+    "$BUILD_ROOT/" "$SOURCE_DIR/"
+
+cd "$WORK_DIR"
+tar -czf "${PACKAGE_NAME}-${VERSION}.tar.gz" "${PACKAGE_NAME}-${VERSION}/"
+
+# Set up makepkg build directory
+BUILD_DIR="$WORK_DIR/build"
+mkdir -p "$BUILD_DIR"
+
+# Copy PKGBUILD and install script
+cp "$ARCH_DIR/PKGBUILD" "$BUILD_DIR/"
+cp "$ARCH_DIR/sudosrv.install" "$BUILD_DIR/"
+
+# Update version in PKGBUILD
+sed -i "s/^pkgver=.*/pkgver=${VERSION}/" "$BUILD_DIR/PKGBUILD"
+
+# Move source tarball next to PKGBUILD
+mv "$WORK_DIR/${PACKAGE_NAME}-${VERSION}.tar.gz" "$BUILD_DIR/"
+
+# Generate checksums
+cd "$BUILD_DIR"
+SHA256=$(sha256sum "${PACKAGE_NAME}-${VERSION}.tar.gz" | awk '{print $1}')
+sed -i "s/sha256sums=('SKIP')/sha256sums=('${SHA256}')/" PKGBUILD
+
+# Build the package
+echo "Running makepkg..."
+makepkg -sf --noconfirm
+
+# Copy resulting package back to project
+mkdir -p "$BUILD_ROOT/archlinux/pkg"
+cp "$BUILD_DIR"/${PACKAGE_NAME}-*.pkg.tar.* "$BUILD_ROOT/archlinux/pkg/" 2>/dev/null || true
+
+echo ""
+echo "Build complete!"
+if ls "$BUILD_ROOT/archlinux/pkg/"${PACKAGE_NAME}-*.pkg.tar.* &>/dev/null; then
+    echo "Package(s):"
+    ls -lh "$BUILD_ROOT/archlinux/pkg/"${PACKAGE_NAME}-*.pkg.tar.*
+    echo ""
+    echo "Install with: sudo pacman -U archlinux/pkg/${PACKAGE_NAME}-${VERSION}-1-*.pkg.tar.*"
+else
+    echo "Warning: No package files found. Check makepkg output above."
+fi
+
+# Clean up
+rm -rf "$WORK_DIR"

--- a/archlinux/sudosrv.conf
+++ b/archlinux/sudosrv.conf
@@ -1,0 +1,25 @@
+server:
+  mode: "local"
+  listen_address: "0.0.0.0:30343"
+  # listen_address_tls: "0.0.0.0:30344"
+  # tls_cert_file: "/etc/sudosrv/server.crt"
+  # tls_key_file: "/etc/sudosrv/server.key"
+  server_id: "GoSudoLogSrv/1.0"
+  idle_timeout: 30m
+  server_operational_log_level: "info"
+
+# Settings for when server.mode is "relay"
+# relay:
+#   upstream_host: "127.0.0.1:30343"
+#   use_tls: false
+#   tls_skip_verify: false
+#   connect_timeout: 5s
+#   relay_cache_directory: "/var/spool/sudosrv-cache"
+#   reconnect_attempts: -1
+#   max_reconnect_interval: "2m"
+
+# Settings for when server.mode is "local"
+local_storage:
+  log_directory: "/var/log/sudosrv"
+  iolog_dir: "%{LIVEDIR}/%{year}/%{month}/%{day}/%{hostname}"
+  iolog_file: "%{user}-%{epoch}-%{rand}"

--- a/archlinux/sudosrv.install
+++ b/archlinux/sudosrv.install
@@ -1,0 +1,22 @@
+post_install() {
+    systemd-sysusers
+    systemd-tmpfiles --create sudosrv.conf
+    echo ":: Enable and start the service with: systemctl enable --now sudosrv.service"
+}
+
+post_upgrade() {
+    systemd-sysusers
+    systemd-tmpfiles --create sudosrv.conf
+    systemctl daemon-reload
+    if systemctl is-active --quiet sudosrv.service; then
+        echo ":: Restarting sudosrv.service..."
+        systemctl restart sudosrv.service
+    fi
+}
+
+pre_remove() {
+    if systemctl is-active --quiet sudosrv.service; then
+        systemctl stop sudosrv.service
+    fi
+    systemctl disable sudosrv.service 2>/dev/null || true
+}

--- a/archlinux/sudosrv.logrotate
+++ b/archlinux/sudosrv.logrotate
@@ -1,0 +1,23 @@
+/var/log/sudosrv/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    create 644 sudosrv sudosrv
+    postrotate
+        /bin/systemctl reload sudosrv.service > /dev/null 2>&1 || true
+    endscript
+}
+
+/var/spool/sudosrv-cache/*.log {
+    weekly
+    missingok
+    rotate 4
+    compress
+    delaycompress
+    notifempty
+    create 644 sudosrv sudosrv
+    maxage 30
+}

--- a/archlinux/sudosrv.service
+++ b/archlinux/sudosrv.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=sudo I/O Log Server
+Documentation=man:sudosrv(8)
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=sudosrv
+Group=sudosrv
+ExecStart=/usr/bin/sudosrv -config=/etc/sudosrv/config.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5s
+TimeoutStartSec=30s
+TimeoutStopSec=30s
+
+# Security settings
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/log/sudosrv /var/spool/sudosrv-cache
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Resource limits
+LimitNOFILE=65536
+LimitNPROC=4096
+
+[Install]
+WantedBy=multi-user.target

--- a/archlinux/sudosrv.sysusers
+++ b/archlinux/sudosrv.sysusers
@@ -1,0 +1,1 @@
+u sudosrv - "sudo I/O log server" /var/lib/sudosrv /usr/bin/nologin

--- a/archlinux/sudosrv.tmpfiles
+++ b/archlinux/sudosrv.tmpfiles
@@ -1,0 +1,2 @@
+d /var/log/sudosrv 0700 sudosrv sudosrv -
+d /var/spool/sudosrv-cache 0700 sudosrv sudosrv -

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Paul Kilar <pkilar@gmail.com>
 Build-Depends: debhelper (>= 13),
-               golang-go (>= 2:1.21),
+               golang-go (>= 2:1.25),
                protobuf-compiler
 Standards-Version: 4.6.2
 Homepage: https://github.com/pkilar/sudosrv

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -43,7 +43,7 @@ rpm/
 ### Prerequisites
 
 - `rpmbuild` and `rpmdevtools` packages
-- Go 1.22 or newer
+- Go 1.25 or newer
 - `protoc` (Protocol Buffer compiler)
 - `make`
 

--- a/rpm/SPECS/sudosrv.spec
+++ b/rpm/SPECS/sudosrv.spec
@@ -9,7 +9,7 @@ License:        MIT
 URL:            https://github.com/example/sudosrv
 Source0:        %{name}-%{version}.tar.gz
 
-BuildRequires:  golang >= 1.22
+BuildRequires:  golang >= 1.25
 BuildRequires:  make
 BuildRequires:  protobuf-compiler
 BuildRequires:  systemd-rpm-macros


### PR DESCRIPTION
## 💪 What

- Adds Arch Linux package build support via PKGBUILD and `make arch` target
- Adds `build-arch.sh` helper script that creates source tarballs and invokes `makepkg`
- Adds systemd integration files following Arch conventions: `sysusers.d` for user creation, `tmpfiles.d` for directory creation, service unit under `/usr/lib/systemd/system/`
- Adds pacman install hooks for service lifecycle management (start/stop/restart on install/upgrade/remove)
- Adds production config, logrotate config, and backup-marked conffiles
- Bumps minimum Go version requirement from 1.21/1.22 to 1.25 across all packaging specs (debian, rpm, archlinux)

## 🤔 Why

- Arch Linux is a common platform for running Go services and the project already supports deb and rpm — this fills the gap for Arch-based systems
- Go 1.25 is the version declared in `go.mod`; the packaging specs were stale and referenced 1.21/1.22

## 👀 Usage

```bash
# Build the Arch package (must be on Arch Linux with base-devel installed)
make arch

# Or run the script directly with a version override
./archlinux/build-arch.sh 0.1.0

# Install the resulting package
sudo pacman -U archlinux/pkg/sudosrv-0.1.0-1-x86_64.pkg.tar.zst

# Enable and start
sudo systemctl enable --now sudosrv.service
```

## 👩‍🔬 How to validate

1. On an Arch Linux system, run `make arch` and confirm a `.pkg.tar.zst` is produced in `archlinux/pkg/`
2. Install with `pacman -U` and verify:
   - `sudosrv` binary exists at `/usr/bin/sudosrv`
   - Config installed at `/etc/sudosrv/config.yaml`
   - `systemctl status sudosrv` shows the service unit loaded
   - `getent passwd sudosrv` shows the system user was created
   - `/var/log/sudosrv` and `/var/spool/sudosrv-cache` directories exist with correct ownership
3. Uninstall with `pacman -R sudosrv` and verify the service is stopped and disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)