### PR TITLE
Fix critical, high, and medium severity issues from code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,166 @@
-# **Go Sudo I/O Log Server**
+# Go Sudo I/O Log Server
 
-This project is a high-performance, standalone I/O log server for sudo, written in Go. It is designed to be a fully compatible alternative to sudo's native `sudo_logsrvd`, capable of receiving and processing detailed I/O logs from any sudo client (version 1.9.0 and newer).
+A high-performance, standalone I/O log server for sudo, written in Go. It is a fully compatible alternative to sudo's native `sudo_logsrvd`, capable of receiving and processing I/O logs from any sudo client (version 1.9.0+).
 
-The server captures a complete transcript of user sessions run via sudo, including all terminal input and output, providing a powerful tool for security auditing, forensic analysis, and troubleshooting.
+The server captures complete transcripts of user sessions run via sudo, including all terminal input and output, providing a tool for security auditing, forensic analysis, and troubleshooting.
 
-## **Features**
+## Features
 
-* **Protocol Compatibility**: Fully implements the `sudo_logsrv.proto` protocol buffer specification used by sudo for remote logging.
-* **Advanced Local Storage**: Saves I/O logs in a format fully compatible with the standard `sudoreplay` utility. It supports highly flexible log path and filename customization through `iolog_dir` and `iolog_file` directives in its configuration, mirroring sudoers functionality.
-* **Resilient Relay Mode**: Acts as a forwarding agent to an upstream log server. Includes a robust store-and-forward caching mechanism, saving logs locally if the upstream server is unavailable and automatically flushing the cache upon reconnection. This prevents data loss during network outages.
-* **Full Escape Sequence Support**: Implements all standard sudoers escape sequences for log path customization, including user (`%{user}`), time (`%{year}`, `%{epoch}`), command (`%{command}`), and generated (`%{seq}`, `%{rand}`) variables.
-* **Dual-Mode Operation**:
-  * **Local Storage Mode**: Saves I/O logs to the local filesystem in a directory structure and format that is **100% compatible with the standard sudoreplay utility**.
-  * **Relay Mode**: Acts as a forwarding agent, relaying logs to another upstream sudo\_logsrvd or compatible server. Includes a **resilient reconnect mechanism** with exponential backoff to handle temporary network interruptions with the upstream server.
-* **Secure Communication**: Supports TLS for encrypting the log stream, ensuring that sensitive session data is protected in transit.
-* **Cross-Platform Binaries**: The included Makefile can produce stripped and statically linked binaries for `linux/amd64` and `linux/arm64` architectures, making deployment simple and portable.
-* **Configurable**: All major settings are managed through a clean `config.yaml` file.
+- **Protocol Compatibility**: Implements the `sudo_logsrv.proto` protocol buffer specification used by sudo for remote logging.
+- **Dual-Mode Operation**:
+  - **Local Storage Mode**: Saves I/O logs to the local filesystem in a format **100% compatible with `sudoreplay`**.
+  - **Relay Mode**: Forwards logs to an upstream `sudo_logsrvd` or compatible server with **store-and-forward caching** and exponential backoff reconnection to handle network interruptions without data loss.
+- **Full Escape Sequence Support**: Implements all standard sudoers escape sequences for log path customization (`%{user}`, `%{seq}`, `%{epoch}`, `%{command}`, etc.).
+- **Password Filtering**: Automatically masks password input in captured sessions (enabled by default).
+- **Secure Communication**: Supports TLS for encrypting log streams in transit. Dual TCP/TLS listeners can run simultaneously.
+- **Packaging**: Debian (`.deb`), RPM, and Arch Linux packages with systemd service units included.
+- **Cross-Platform Binaries**: Stripped and statically linked binaries for `linux/amd64` and `linux/arm64`.
+- **Configurable**: All settings managed through a `config.yaml` file.
 
-## **Getting Started**
+## Getting Started
 
-### **Prerequisites**
+### Prerequisites
 
-* Go (version 1.22 or newer)
-* Protocol Buffer Compiler (protoc)
-* make
+- Go 1.25+
+- Protocol Buffer Compiler (`protoc`) and `protoc-gen-go`
+- `make`
 
-### **Building the Server**
+### Building
 
-A comprehensive Makefile handles all common tasks.
-
-1. **Generate Protobuf Code & Tidy Dependencies**:
-```
-make deps
-```
-
-2. **Build the Binary**:
-   * For your local architecture:
-```
+```bash
+# Build for local architecture (auto-runs proto generation + go mod tidy)
 make build
-```
 
-   * To build stripped, cross-compiled release binaries:
-```
+# Build stripped release binary
+make build-release
+
+# Cross-compile release binaries (linux-amd64 + linux-arm64)
 make release-all
-```
 
-   * To build statically linked binaries:
-```
+# Build statically linked binaries (CGO_ENABLED=0)
 make release-static-all
 ```
 
-### **Running Tests**
+### Running Tests
 
-To run all unit tests for the project:
-```
+```bash
 make test
 ```
 
-### **Running the Server**
+### Running the Server
 
-1. Create a config.yaml file from the example in internal/config/config.go.
-2. Run the server:
-```
+1. Copy `config-example.yaml` to `config.yaml` and edit to suit your environment.
+2. Run:
+
+```bash
 make run
 ```
 
-   Or specify a config file path:
-```
+Or specify a config file path:
+
+```bash
 make run CONFIG=/etc/sudosrv/config.yaml
 ```
 
-## **Client Configuration (sudoers)**
+### CLI Flags
 
-To configure a sudo client to send its I/O logs to this server, edit /etc/sudoers using visudo:
+```
+-config=<path>       Path to configuration file (default: config.yaml)
+-log-level=<level>   Log level: debug, info, warn, error
+-version             Print version and exit
+-help                Print usage and exit
+-dry-run             Validate configuration and exit without starting
+-validate            Validate configuration file
+```
+
+**Exit codes**: `0` success, `1` general failure, `2` configuration error, `3` server error
+
+## Configuration
+
+Example `config.yaml`:
+
+```yaml
+server:
+  mode: "local"                    # "local" or "relay"
+  listen_address: "0.0.0.0:30343"
+  # listen_address_tls: "0.0.0.0:30344"
+  # tls_cert_file: "server.crt"
+  # tls_key_file: "server.key"
+  idle_timeout: 30m
+  server_operational_log_level: "info"
+
+# Settings for when server.mode is "local"
+local_storage:
+  log_directory: "/var/log/gosudo-io"
+  # iolog_dir: "%{LIVEDIR}/%{user}"
+  # iolog_file: "%{seq}"
+  # dir_permissions: 0750
+  # file_permissions: 0640
+  # compress: false
+  # password_filter: true
+
+# Settings for when server.mode is "relay"
+relay:
+  upstream_host: "127.0.0.1:30344"
+  use_tls: false
+  connect_timeout: 15s
+  relay_cache_directory: "/var/log/gosudo-relay-cache"
+  reconnect_attempts: -1           # -1 = infinite
+  # max_reconnect_interval: 1m
+```
+
+### Supported Escape Sequences
+
+For `iolog_dir` and `iolog_file`:
+
+| Category | Sequences |
+|----------|-----------|
+| User | `%{user}`, `%{uid}`, `%{group}`, `%{gid}` |
+| RunAs | `%{runuser}`, `%{runuid}`, `%{rungroup}`, `%{rungid}` |
+| Host/Command | `%{hostname}`, `%{command}`, `%{command_path}` |
+| Time | `%{year}`, `%{month}`, `%{day}`, `%{hour}`, `%{minute}`, `%{second}`, `%{epoch}` |
+| Generated | `%{seq}`, `%{rand}`, `%{LIVEDIR}`, `%%` |
+
+## Packaging
+
+```bash
+make deb    # Debian package (requires dpkg-buildpackage)
+make rpm    # RPM package
+make arch   # Arch Linux package (requires makepkg)
+```
+
+All packages include a systemd service unit, logrotate configuration, and sane defaults.
+
+## Client Configuration (sudoers)
+
+To configure a sudo client to send I/O logs to this server, edit `/etc/sudoers` using `visudo`:
+
 ```
 # Enable I/O logging for all commands
 Defaults log_input, log_output
 
-# Send logs to your Go server instance
+# Send logs to your server instance
 Defaults log_servers="your-server-hostname:30344(tls)"
 
 # If using a self-signed or private CA for the server's TLS cert
 Defaults log_server_cabundle=/etc/sudo/ca.pem
 ```
+
+## Project Structure
+
+```
+cmd/sudosrv/         Entry point — flag parsing, config, signal handling
+internal/
+  config/            YAML configuration with defaults
+  connection/        Protocol state machine & rate limiting
+  protocol/          Length-prefixed protobuf message marshaling
+  server/            Dual TCP/TLS listener management
+  storage/           sudoreplay-compatible local log storage
+  relay/             Store-and-forward relay with reconnection
+  metrics/           Atomic connection/session/error counters
+pkg/sudosrv_proto/   Generated protobuf definitions
+```
+
+## License
+
+See [LICENSE](LICENSE) for details.

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -317,7 +317,8 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 
 	if err := os.MkdirAll(rejectDir, os.FileMode(h.config.LocalStorage.DirPermissions)); err != nil {
 		slog.Error("Failed to create reject event directory", "error", err, "path", rejectDir)
-		return nil, nil // Non-fatal
+		metrics.Global.IncrementMessageErrors()
+		return nil, nil
 	}
 
 	// Build the event record
@@ -355,13 +356,15 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 	data, err := json.MarshalIndent(eventRecord, "", "  ")
 	if err != nil {
 		slog.Error("Failed to marshal reject event", "error", err)
-		return nil, nil // Non-fatal
+		metrics.Global.IncrementMessageErrors()
+		return nil, nil
 	}
 
 	logJSONPath := filepath.Join(rejectDir, "log.json")
 	if err := os.WriteFile(logJSONPath, data, os.FileMode(h.config.LocalStorage.FilePermissions)); err != nil {
 		slog.Error("Failed to write reject event log", "error", err, "path", logJSONPath)
-		return nil, nil // Non-fatal
+		metrics.Global.IncrementMessageErrors()
+		return nil, nil
 	}
 
 	slog.Info("Wrote reject event log", "path", logJSONPath, "reason", rejectMsg.GetReason())

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,109 +7,125 @@ import (
 )
 
 // Metrics holds basic operational metrics for the server.
+// All counter fields use atomic.Int64 to enforce atomic access at the type level,
+// preventing accidental non-atomic reads or writes.
 type Metrics struct {
-	// Connection metrics
-	TotalConnections  int64
-	ActiveConnections int64
-	FailedConnections int64
+	totalConnections  atomic.Int64
+	activeConnections atomic.Int64
+	failedConnections atomic.Int64
 
-	// Session metrics
-	TotalSessions  int64
-	ActiveSessions int64
-	LocalSessions  int64
-	RelaySessions  int64
+	totalSessions  atomic.Int64
+	activeSessions atomic.Int64
+	localSessions  atomic.Int64
+	relaySessions  atomic.Int64
 
-	// Message metrics
-	MessagesProcessed int64
-	MessageErrors     int64
+	messagesProcessed atomic.Int64
+	messageErrors     atomic.Int64
 
-	// Timing metrics
-	ServerStartTime time.Time
+	serverStartTime time.Time
 }
 
 // Global metrics instance
-var Global = &Metrics{
-	ServerStartTime: time.Now(),
+var Global = newMetrics()
+
+func newMetrics() *Metrics {
+	return &Metrics{
+		serverStartTime: time.Now(),
+	}
 }
 
 // Connection tracking
 func (m *Metrics) IncrementConnections() {
-	atomic.AddInt64(&m.TotalConnections, 1)
-	atomic.AddInt64(&m.ActiveConnections, 1)
+	m.totalConnections.Add(1)
+	m.activeConnections.Add(1)
 }
 
 func (m *Metrics) DecrementActiveConnections() {
-	atomic.AddInt64(&m.ActiveConnections, -1)
+	m.activeConnections.Add(-1)
 }
 
 func (m *Metrics) IncrementFailedConnections() {
-	atomic.AddInt64(&m.FailedConnections, 1)
+	m.failedConnections.Add(1)
 }
 
 // Session tracking
 func (m *Metrics) IncrementSessions() {
-	atomic.AddInt64(&m.TotalSessions, 1)
-	atomic.AddInt64(&m.ActiveSessions, 1)
+	m.totalSessions.Add(1)
+	m.activeSessions.Add(1)
 }
 
 func (m *Metrics) DecrementActiveSessions() {
-	atomic.AddInt64(&m.ActiveSessions, -1)
+	m.activeSessions.Add(-1)
 }
 
 func (m *Metrics) IncrementLocalSessions() {
-	atomic.AddInt64(&m.LocalSessions, 1)
+	m.localSessions.Add(1)
 }
 
 func (m *Metrics) IncrementRelaySessions() {
-	atomic.AddInt64(&m.RelaySessions, 1)
+	m.relaySessions.Add(1)
 }
 
 // Message tracking
 func (m *Metrics) IncrementMessagesProcessed() {
-	atomic.AddInt64(&m.MessagesProcessed, 1)
+	m.messagesProcessed.Add(1)
 }
 
 func (m *Metrics) IncrementMessageErrors() {
-	atomic.AddInt64(&m.MessageErrors, 1)
+	m.messageErrors.Add(1)
 }
 
 // Getters for safe reading
 func (m *Metrics) GetTotalConnections() int64 {
-	return atomic.LoadInt64(&m.TotalConnections)
+	return m.totalConnections.Load()
 }
 
 func (m *Metrics) GetActiveConnections() int64 {
-	return atomic.LoadInt64(&m.ActiveConnections)
+	return m.activeConnections.Load()
 }
 
 func (m *Metrics) GetFailedConnections() int64 {
-	return atomic.LoadInt64(&m.FailedConnections)
+	return m.failedConnections.Load()
 }
 
 func (m *Metrics) GetTotalSessions() int64 {
-	return atomic.LoadInt64(&m.TotalSessions)
+	return m.totalSessions.Load()
 }
 
 func (m *Metrics) GetActiveSessions() int64 {
-	return atomic.LoadInt64(&m.ActiveSessions)
+	return m.activeSessions.Load()
 }
 
 func (m *Metrics) GetLocalSessions() int64 {
-	return atomic.LoadInt64(&m.LocalSessions)
+	return m.localSessions.Load()
 }
 
 func (m *Metrics) GetRelaySessions() int64 {
-	return atomic.LoadInt64(&m.RelaySessions)
+	return m.relaySessions.Load()
 }
 
 func (m *Metrics) GetMessagesProcessed() int64 {
-	return atomic.LoadInt64(&m.MessagesProcessed)
+	return m.messagesProcessed.Load()
 }
 
 func (m *Metrics) GetMessageErrors() int64 {
-	return atomic.LoadInt64(&m.MessageErrors)
+	return m.messageErrors.Load()
 }
 
 func (m *Metrics) GetUptime() time.Duration {
-	return time.Since(m.ServerStartTime)
+	return time.Since(m.serverStartTime)
+}
+
+// Reset resets all counters to zero. Intended for use in tests.
+func (m *Metrics) Reset() {
+	m.totalConnections.Store(0)
+	m.activeConnections.Store(0)
+	m.failedConnections.Store(0)
+	m.totalSessions.Store(0)
+	m.activeSessions.Store(0)
+	m.localSessions.Store(0)
+	m.relaySessions.Store(0)
+	m.messagesProcessed.Store(0)
+	m.messageErrors.Store(0)
+	m.serverStartTime = time.Now()
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -117,11 +117,12 @@ local_storage:
 
 		srv.reload()
 
-		if srv.config.Server.ServerID != "TestServer/2.0" {
-			t.Errorf("Expected server_id 'TestServer/2.0', got '%s'", srv.config.Server.ServerID)
+		loadedCfg := srv.config.Load()
+		if loadedCfg.Server.ServerID != "TestServer/2.0" {
+			t.Errorf("Expected server_id 'TestServer/2.0', got '%s'", loadedCfg.Server.ServerID)
 		}
-		if srv.config.LocalStorage.LogDirectory != "/tmp/test-logs-v2" {
-			t.Errorf("Expected log_directory '/tmp/test-logs-v2', got '%s'", srv.config.LocalStorage.LogDirectory)
+		if loadedCfg.LocalStorage.LogDirectory != "/tmp/test-logs-v2" {
+			t.Errorf("Expected log_directory '/tmp/test-logs-v2', got '%s'", loadedCfg.LocalStorage.LogDirectory)
 		}
 		if logLevel.Level() != slog.LevelError {
 			t.Errorf("Expected log level ERROR, got %s", logLevel.Level())


### PR DESCRIPTION
## 💪 What

- Fixes unconditional cache file deletion in relay flush that caused **data loss** on upstream connection errors (critical)
- Replaces exported `int64` metric fields with `atomic.Int64` types, preventing non-atomic access at compile time
- Adds `atomic.Pointer[config.Config]` for thread-safe SIGHUP configuration reload — existing connections keep their config snapshot while new connections pick up changes
- Wraps storage session `Close()` in `sync.Once` to prevent double-close panics
- Honors configured file permissions when creating I/O stream files (was hardcoded 0666 via `os.Create`)
- Adds message size validation on relay cache reads before allocating memory
- Fixes data race on shared slice in connection handler tests
- Adds TLS 1.2 minimum version, listener cleanup on partial bind failure, and accept loop backoff
- Replaces `strings.Contains` error classification with sentinel error types and `errors.As` for exit codes
- Adds equal jitter to relay reconnect backoff to prevent thundering herd
- Combines protocol write into single syscall for atomicity; adds outgoing message size check
- Updates README with complete project documentation

## 🤔 Why

- The relay cache deletion bug is a **data loss risk** — if the upstream server rejects or drops the connection during flush, the cached session log is permanently deleted with no way to recover
- Raw `int64` fields with `atomic.AddInt64()` don't prevent direct (non-atomic) field access — `atomic.Int64` types enforce safety at the type level
- The server's `config` field was a plain pointer mutated during SIGHUP reload while accept loops read it concurrently — a textbook data race
- Several medium-severity issues (missing TLS floor, tight error loops, permission mismatches) reduce production hardening

## 👩‍🔬 How to validate

1. **Relay data loss fix**: Start the server in relay mode with an unreachable upstream. Send a complete session (through ExitMessage). Verify the `.log` cache file persists in `relay_cache_directory` after the failed flush attempt — previously it would be deleted.

2. **Atomic config reload**: Start the server, send a SIGHUP, then connect a new client. The new connection should use the reloaded config (e.g., changed `server_id` appears in ServerHello). No race detector warnings under `-race`.

3. **TLS minimum version**: Attempt a TLS 1.0 or 1.1 connection to the TLS listener — it should be rejected. TLS 1.2+ should succeed.

4. **File permissions**: Create a local storage session and verify the I/O stream files (`ttyin`, `ttyout`, etc.) respect the `file_permissions` config value instead of defaulting to 0666.