### PR TITLE
Fix critical, high, and medium severity issues from code review

### DIFF
--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -368,8 +368,8 @@ func writeProtoMessage(w io.Writer, msg *pb.ClientMessage) error {
 		return err
 	}
 	l := len(data)
-	if l > math.MaxInt-4 {
-		return fmt.Errorf("message too large: length %d exceeds limit", l)
+	if uint32(l) > maxMessageSize {
+		return fmt.Errorf("message too large: length %d exceeds limit of %d", l, maxMessageSize)
 	}
 	buf := make([]byte, 4+l)
 	binary.BigEndian.PutUint32(buf[:4], uint32(l))

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -367,8 +367,12 @@ func writeProtoMessage(w io.Writer, msg *pb.ClientMessage) error {
 	if err != nil {
 		return err
 	}
-	buf := make([]byte, 4+len(data))
-	binary.BigEndian.PutUint32(buf[:4], uint32(len(data)))
+	l := len(data)
+	if l > math.MaxInt-4 {
+		return fmt.Errorf("message too large: length %d exceeds limit", l)
+	}
+	buf := make([]byte, 4+l)
+	binary.BigEndian.PutUint32(buf[:4], uint32(l))
 	copy(buf[4:], data)
 	_, err = w.Write(buf)
 	return err

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -42,6 +42,7 @@ type Session struct {
 	initialAcceptMsg *pb.AcceptMessage
 	fromClientChan   chan *pb.ClientMessage
 	wg               sync.WaitGroup
+	closeOnce        sync.Once
 	cacheFileName    string
 	cumulativeDelay  map[string]time.Duration // Tracks cumulative I/O delay per stream for commit points
 	lastCommitTime   time.Time               // When last commit point was sent to client
@@ -245,9 +246,12 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 
 // Close is called by the connection handler when the client disconnects.
 // It signals the messageWriter to stop accepting new messages.
+// Safe to call multiple times; only the first call closes the channel.
 func (s *Session) Close() error {
-	slog.Info("Client connection closed. Relay session writer will now complete.", "log_id", s.logID)
-	close(s.fromClientChan) // Signal the messageWriter loop to terminate.
+	s.closeOnce.Do(func() {
+		slog.Info("Client connection closed. Relay session writer will now complete.", "log_id", s.logID)
+		close(s.fromClientChan) // Signal the messageWriter loop to terminate.
+	})
 
 	// Wait for goroutine to finish, but don't cancel context yet to allow natural completion
 	s.wg.Wait()
@@ -260,14 +264,14 @@ func (s *Session) Close() error {
 // ---- Standalone Flusher for Orphaned Files ----
 
 // FlushOrphanedFile connects to upstream and sends the content of a single file.
-func FlushOrphanedFile(filePath string, cfg *config.RelayConfig) {
+func FlushOrphanedFile(filePath string, cfg *config.RelayConfig) error {
 	slog.Info("Found orphaned relay file, attempting to flush", "path", filePath)
 
 	// Rename file to prevent another process from picking it up
 	flushingFileName := filePath + flushingSuffix
 	if err := os.Rename(filePath, flushingFileName); err != nil {
 		slog.Error("Could not rename orphaned file for flushing", "path", filePath, "error", err)
-		return
+		return fmt.Errorf("could not rename orphaned file %s: %w", filePath, err)
 	}
 
 	proc, err := connectToUpstream(cfg)
@@ -276,7 +280,7 @@ func FlushOrphanedFile(filePath string, cfg *config.RelayConfig) {
 		if renameErr := os.Rename(flushingFileName, filePath); renameErr != nil {
 			slog.Error("Failed to rename orphaned file back after connection failure", "path", flushingFileName, "error", renameErr)
 		}
-		return
+		return fmt.Errorf("failed to connect to upstream for %s: %w", filePath, err)
 	}
 
 	err = flushFile(proc, flushingFileName)
@@ -286,9 +290,10 @@ func FlushOrphanedFile(filePath string, cfg *config.RelayConfig) {
 		if renameErr := os.Rename(flushingFileName, filePath); renameErr != nil {
 			slog.Error("Failed to rename orphaned file back after flush failure", "path", flushingFileName, "error", renameErr)
 		}
-		return
+		return fmt.Errorf("failed to flush orphaned file %s: %w", filePath, err)
 	}
 	slog.Info("Successfully flushed orphaned relay file", "path", flushingFileName)
+	return nil
 }
 
 func flushFile(proc protocol.Processor, filePath string) error {
@@ -330,7 +335,7 @@ func connectToUpstream(cfg *config.RelayConfig) (protocol.Processor, error) {
 
 	slog.Debug("Dialing upstream", "host", cfg.UpstreamHost, "use_tls", cfg.UseTLS, "tls_skip_verify", cfg.TLSSkipVerify)
 	if cfg.UseTLS {
-		tlsConfig := &tls.Config{InsecureSkipVerify: cfg.TLSSkipVerify}
+		tlsConfig := &tls.Config{InsecureSkipVerify: cfg.TLSSkipVerify, MinVersion: tls.VersionTLS12}
 		conn, err = tls.DialWithDialer(dialer, "tcp", cfg.UpstreamHost, tlsConfig)
 	} else {
 		conn, err = dialer.Dial("tcp", cfg.UpstreamHost)
@@ -355,17 +360,17 @@ func connectToUpstream(cfg *config.RelayConfig) (protocol.Processor, error) {
 }
 
 // writeProtoMessage serializes and writes a single protobuf message with its length prefix.
+// Length prefix and payload are combined into a single write for atomicity — a partial
+// write (e.g., process crash) won't leave a length prefix without a payload.
 func writeProtoMessage(w io.Writer, msg *pb.ClientMessage) error {
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		return err
 	}
-	lenBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))
-	if _, err := w.Write(lenBuf); err != nil {
-		return err
-	}
-	_, err = w.Write(data)
+	buf := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(buf[:4], uint32(len(data)))
+	copy(buf[4:], data)
+	_, err = w.Write(buf)
 	return err
 }
 


### PR DESCRIPTION
## 💪 What

- Fixes double-close panic on relay session channel by wrapping `close(fromClientChan)` in `sync.Once`
- Adds nil guards for protobuf fields (`delay`, `submit_time`) in storage session to prevent nil pointer dereferences from malformed client messages
- Combines length prefix and payload into a single `Write` call in relay cache writer for atomic file writes, preventing partial writes on crash
- Sets `MinVersion: tls.VersionTLS12` on upstream relay TLS config to prevent protocol downgrade attacks
- Propagates errors from `FlushOrphanedFile` back to caller and fixes variable shadowing of `errors` import

## 🤔 Why

- The relay session `Close()` method could be called multiple times (e.g., deferred cleanup + explicit close), causing a panic on the already-closed channel — this is the most critical fix
- Protobuf generated code returns `nil` for unset message fields; without nil guards, a malformed `AcceptMessage` or I/O buffer causes a server crash
- Split writes (length prefix then payload) risk leaving a corrupt cache file if the process crashes between the two writes
- Without `MinVersion`, Go's TLS defaults allow TLS 1.0/1.1 which have known vulnerabilities
- Orphaned file flush errors were silently discarded, making relay failures invisible in production

## 👩‍🔬 How to validate

1. **Double-close fix**: Inspect `internal/relay/session.go` — `Close()` now uses `sync.Once` to guard channel close
2. **Nil guards**: Inspect `internal/storage/session.go` — `writeIoEntry`, `handleWinsize`, `handleSuspend`, and `initialize` now check for nil before dereferencing
3. **Atomic writes**: Inspect `writeProtoMessage` in `internal/relay/session.go` — single buffer allocation + single `Write` call
4. **TLS MinVersion**: Inspect `connectToUpstream` in `internal/relay/session.go` — `tls.Config` now includes `MinVersion: tls.VersionTLS12`
5. **Error propagation**: Inspect `FlushOrphanedFile` return type and `flushOrphanedRelayFiles` in `cmd/sudosrv/main.go` — errors now flow through the channel
6. Run `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)