### PR TITLE
Fix data race, goroutine leak, and 8 other code review issues

### DIFF
--- a/cmd/sudosrv/main.go
+++ b/cmd/sudosrv/main.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sudosrv/internal/config"
 	"sudosrv/internal/relay"
 	"sudosrv/internal/server"
@@ -199,7 +198,7 @@ func setupStructuredLogging(cfg *config.Config, logLevelOverride string) (*slog.
 		logLevelStr = logLevelOverride
 	}
 
-	parsedLevel, err := parseLogLevel(logLevelStr)
+	parsedLevel, err := config.ParseLogLevel(logLevelStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid log level: %w", err)
 	}
@@ -231,22 +230,6 @@ func setupStructuredLogging(cfg *config.Config, logLevelOverride string) (*slog.
 		"source_enabled", handlerOpts.AddSource)
 
 	return logLevel, nil
-}
-
-// parseLogLevel converts string log level to slog.Level with validation
-func parseLogLevel(levelStr string) (slog.Level, error) {
-	switch strings.ToLower(strings.TrimSpace(levelStr)) {
-	case "debug":
-		return slog.LevelDebug, nil
-	case "info":
-		return slog.LevelInfo, nil
-	case "warn", "warning":
-		return slog.LevelWarn, nil
-	case "error":
-		return slog.LevelError, nil
-	default:
-		return slog.LevelInfo, fmt.Errorf("unknown log level: %s (supported: debug, info, warn, error)", levelStr)
-	}
 }
 
 // initializeRelayMode handles relay-specific initialization

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -2,6 +2,7 @@
 package relay
 
 import (
+	"context"
 	"io"
 	"net"
 	"os"
@@ -174,7 +175,7 @@ func TestRelaySession_CacheAndFlush(t *testing.T) {
 	acceptMsg := createTestAcceptMessage()
 
 	// 3. Create a new relay session
-	session, err := NewSession(sessionUUID, acceptMsg, relayCfg)
+	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -263,7 +264,7 @@ func TestRelayCommitPoints(t *testing.T) {
 	sessionUUID := uuid.MustParse("b2c3d4e5-f6a7-4b2c-9d3e-0f1a2b3c4d5e")
 	acceptMsg := createTestAcceptMessage()
 
-	session, err := NewSession(sessionUUID, acceptMsg, relayCfg)
+	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -337,7 +338,7 @@ func TestRelayCommitPointThrottling(t *testing.T) {
 	sessionUUID := uuid.MustParse("c3d4e5f6-a7b8-4c3d-ae4f-1a2b3c4d5e6f")
 	acceptMsg := createTestAcceptMessage()
 
-	session, err := NewSession(sessionUUID, acceptMsg, relayCfg)
+	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -374,7 +375,9 @@ func TestRelayCommitPointThrottling(t *testing.T) {
 	}
 
 	// Backdate lastCommitTime to simulate time passing
+	session.mu.Lock()
 	session.lastCommitTime = time.Now().Add(-commitPointInterval - time.Second)
+	session.mu.Unlock()
 
 	// Next event should return a commit point
 	resp, err = session.HandleClientMessage(makeIoMsg())

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -86,7 +86,12 @@ var validSuspendSignals = map[string]bool{
 	"TTOU": true,
 }
 
-// Per-directory mutexes for sequence file access to reduce contention
+// seqMutexMap holds per-directory mutexes for sequence file access to reduce
+// contention. Entries are never removed because the set of distinct log
+// directories is expected to be small and stable (typically one per
+// iolog_dir template). If the deployment creates directories dynamically
+// at a high rate, this map will grow unboundedly; in that scenario consider
+// adding an eviction policy.
 var seqMutexMap = make(map[string]*sync.Mutex)
 var seqMutexMapLock sync.RWMutex
 


### PR DESCRIPTION
## 💪 What

- Fixes a data race on relay session's `cumulativeDelay` and `lastCommitTime` fields by adding mutex synchronization
- Fixes a goroutine leak in `writeMessagesToCache` where the background goroutine could block forever if `Close()` was never called — now respects context cancellation
- Fixes an integer overflow bug in `writeProtoMessage` where `uint32(l)` silently truncated `len(data)` on 64-bit systems, bypassing the 2MB message size check
- Removes the redundant `quit` channel from `Server`, eliminating a potential double-close panic — context cancellation alone handles shutdown signaling
- Consolidates three identical `parseLogLevel` functions into a single exported `config.ParseLogLevel`
- Adds `reinterpretDecimalAsOctal` helper that auto-corrects YAML 1.2 file permission values (e.g., `0750` parsed as decimal 750 → octal 0o750 = 488)
- Propagates parent context into `relay.NewSession` so server shutdown cancellation reaches relay session goroutines
- Documents `handleReject`'s intentional best-effort error handling design
- Documents the `seqMutexMap` growth assumption

## 🤔 Why

- The data race (issue 1) could cause corrupted commit point timestamps under concurrent I/O, leading to incorrect session replay timing
- The goroutine leak (issue 2) means abandoned relay sessions accumulate goroutines that never exit, slowly exhausting server memory
- The uint32 truncation (issue 4) means a crafted message >4GB could bypass the size check on 64-bit systems — a correctness and potential security concern
- The dual shutdown mechanism (issues 5-6) was unnecessary complexity with a latent double-close panic if shutdown ordering changed
- Three identical `parseLogLevel` copies (issue 7) meant bug fixes would need to be applied in three places
- YAML 1.2's decimal parsing of `0750` is a well-known footgun — auto-correction prevents sessions being created with wrong permissions (issue 9)
- Without parent context propagation (issue 10), relay sessions ignore server shutdown and continue retry loops indefinitely

## 👩‍🔬 How to validate

1. **Data race detection**: Run `go test -race ./internal/relay/` — previously this could flag races on `cumulativeDelay`/`lastCommitTime` under high concurrency
2. **Goroutine leak**: The `writeMessagesToCache` loop now has a `case <-s.ctx.Done()` path — inspect the diff in `internal/relay/session.go`
3. **uint32 fix**: Check line ~385 of `internal/relay/session.go` — comparison is now `l > maxMessageSize` (int) instead of `uint32(l) > maxMessageSize`
4. **Shutdown simplification**: Grep for `quit` in `internal/server/server.go` — it should no longer exist
5. **ParseLogLevel consolidation**: Verify `config.ParseLogLevel` is used in both `cmd/sudosrv/main.go` and `internal/server/server.go`, and no local copies remain
6. **Permission auto-correction**: Review the `reinterpretDecimalAsOctal` function in `internal/config/config.go` — it converts decimal 750 → octal 488 when all digits are 0-7
7. **All tests pass**: `go test ./...` and `go vet ./...` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)