### PR TITLE
Potential fix for code scanning alert no. 4: Size computation for allocation may overflow

### DIFF
--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -498,6 +498,9 @@ func writeProtoMessage(w io.Writer, msg *pb.ClientMessage) error {
 	if l > protocol.MaxMessageSize {
 		return fmt.Errorf("message too large: length %d exceeds limit of %d", l, protocol.MaxMessageSize)
 	}
+	if l > math.MaxInt-4 {
+		return fmt.Errorf("message too large: length %d overflows framed allocation", l)
+	}
 	buf := make([]byte, 4+l)
 	binary.BigEndian.PutUint32(buf[:4], uint32(l))
 	copy(buf[4:], data)


### PR DESCRIPTION
Potential fix for [https://github.com/pkilar/sudosrv-go/security/code-scanning/4](https://github.com/pkilar/sudosrv-go/security/code-scanning/4)

Add an explicit overflow-safe bound check before `make([]byte, 4+l)` in `writeProtoMessage`:

1. Keep the existing `l > protocol.MaxMessageSize` check.
2. Add `if l > math.MaxInt-4 { return error }` before allocation.
3. Then allocate with `make([]byte, 4+l)` as before.

This is the best minimal fix because it directly guards the exact allocation expression flagged by CodeQL, does not change message format or normal functionality, and uses existing imports (`math` is already imported in this file).  
Only edit `internal/relay/session.go` in `writeProtoMessage` around lines 497–502.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
