### PR TITLE
Add management API for listing active sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ relay:
   relay_cache_directory: "/var/log/gosudo-relay-cache"
   reconnect_attempts: -1           # -1 = infinite
   # max_reconnect_interval: 1m
+
+# Optional read-only management API. Omit the block (or leave listen_address
+# empty) to disable. See "Management API" below for endpoint details.
+# api:
+#   listen_address: "127.0.0.1:30345"
+#   auth_token_file: "/etc/sudosrv/api.token"
+#   # tls_cert_file: "api.crt"
+#   # tls_key_file:  "api.key"
 ```
 
 ### Supported Escape Sequences
@@ -120,6 +128,56 @@ For `iolog_dir` and `iolog_file`:
 | Host/Command | `%{hostname}`, `%{command}`, `%{command_path}` |
 | Time | `%{year}`, `%{month}`, `%{day}`, `%{hour}`, `%{minute}`, `%{second}`, `%{epoch}` |
 | Generated | `%{seq}`, `%{rand}`, `%{LIVEDIR}`, `%%` |
+
+## Management API
+
+An optional read-only HTTP+JSON API exposes currently active sessions for
+operational visibility. The API is **disabled by default** — set
+`api.listen_address` to enable it.
+
+### Configuration
+
+```yaml
+api:
+  listen_address: "127.0.0.1:30345"        # empty disables the API
+  auth_token_file: "/etc/sudosrv/api.token" # preferred over inline auth_token
+  # auth_token: "raw-token"                 # alternative; inline (discouraged)
+  # tls_cert_file: "api.crt"                # optional TLS for the listener
+  # tls_key_file:  "api.key"
+```
+
+The bearer token is loaded once at startup; rotating it requires a restart.
+Bind to localhost unless TLS and a strong token are in place.
+
+### Endpoints
+
+Both endpoints require an `Authorization: Bearer <token>` header.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/sessions` | Summary list of active sessions, newest first. |
+| GET | `/api/v1/sessions/{id}` | Full metadata for one session, looked up by `session_id` (UUID) or `server_log_id` (base64). URL-escape the segment when using `server_log_id` because it may contain `/`. |
+
+### Example
+
+```bash
+TOKEN=$(cat /etc/sudosrv/api.token)
+
+# List active sessions
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:30345/api/v1/sessions
+
+# Inspect one session
+curl -H "Authorization: Bearer $TOKEN" \
+     http://127.0.0.1:30345/api/v1/sessions/fb8f1722-2cdc-45e6-967f-22e39b2b465b
+```
+
+The detail response includes a `live` block with running counters
+(`messages_received`, `bytes_received`, `last_activity`) and mode-specific
+fields (`session_dir` for local mode; `cache_file` and `phase` —
+`writing`/`flushing` — for relay mode).
+
+Errors are returned as `{"error": "..."}` with `401` for missing or invalid
+tokens and `404` for unknown session IDs.
 
 ## Packaging
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -17,3 +17,12 @@ relay:
   connect_timeout: 15s
   relay_cache_directory: "/tmp/sudosrv-cache"
   reconnect_attempts: -1
+
+# Optional read-only management HTTP API.
+# Leave listen_address empty (or omit the entire api: block) to disable it.
+#api:
+#  listen_address: "127.0.0.1:30345"
+#  auth_token_file: "/etc/sudosrv/api.token"  # preferred; file content is the bearer token
+#  # auth_token: "raw-token-here"             # alternative; inline (discouraged for prod)
+#  # tls_cert_file: "api.crt"                 # optional TLS for the API listener
+#  # tls_key_file:  "api.key"

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,301 @@
+// Package api implements the optional management HTTP API for sudosrv. It
+// exposes read-only endpoints for enumerating active sessions and querying
+// per-session metadata. Authentication is a static bearer token loaded from
+// configuration; transport security is provided by an optional TLS listener.
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sudosrv/internal/config"
+	"sudosrv/internal/sessions"
+	"time"
+)
+
+// Server owns the management HTTP server. Construct with NewServer, then call
+// Listen synchronously to bind the address (so port-in-use and TLS load
+// errors surface at startup), and finally Serve to begin handling requests.
+// Shutdown stops Serve cleanly.
+type Server struct {
+	cfg      config.APIConfig
+	registry *sessions.Registry
+	httpSrv  *http.Server
+	listener net.Listener
+	token    string
+}
+
+// NewServer validates the configuration, loads the bearer token, and prepares
+// an *http.Server. The server is not yet listening when this returns; call
+// Listen to bind synchronously, then Serve to begin handling requests.
+func NewServer(cfg config.APIConfig, registry *sessions.Registry) (*Server, error) {
+	if cfg.ListenAddress == "" {
+		return nil, errors.New("api: ListenAddress is required")
+	}
+	if registry == nil {
+		return nil, errors.New("api: registry is required")
+	}
+	token, err := loadToken(cfg)
+	if err != nil {
+		return nil, err
+	}
+	s := &Server{cfg: cfg, registry: registry, token: token}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions", s.authMW(s.handleList))
+	mux.HandleFunc("GET /api/v1/sessions/{id}", s.authMW(s.handleGet))
+
+	s.httpSrv = &http.Server{
+		Addr:              cfg.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	return s, nil
+}
+
+// Listen synchronously binds the configured address and, if TLS is configured,
+// loads and validates the certificate pair. Bind failures (e.g. port already
+// in use) and TLS-load failures are returned here so callers can detect them
+// at startup rather than discover the API silently absent.
+func (s *Server) Listen() error {
+	if s.listener != nil {
+		return errors.New("api: Listen called more than once")
+	}
+	if s.cfg.TLSCertFile != "" && s.cfg.TLSKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(s.cfg.TLSCertFile, s.cfg.TLSKeyFile)
+		if err != nil {
+			return fmt.Errorf("api: load tls keypair: %w", err)
+		}
+		ln, err := tls.Listen("tcp", s.cfg.ListenAddress, &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS13,
+		})
+		if err != nil {
+			return fmt.Errorf("api: listen on %s: %w", s.cfg.ListenAddress, err)
+		}
+		s.listener = ln
+		return nil
+	}
+	ln, err := net.Listen("tcp", s.cfg.ListenAddress)
+	if err != nil {
+		return fmt.Errorf("api: listen on %s: %w", s.cfg.ListenAddress, err)
+	}
+	s.listener = ln
+	return nil
+}
+
+// Serve handles HTTP requests on the listener bound by Listen. It blocks
+// until Shutdown is called and returns http.ErrServerClosed in that case.
+func (s *Server) Serve() error {
+	if s.listener == nil {
+		return errors.New("api: Serve called before Listen")
+	}
+	return s.httpSrv.Serve(s.listener)
+}
+
+// Addr returns the bound listener's address. Useful in tests where the
+// configured address may use port 0.
+func (s *Server) Addr() net.Addr {
+	if s.listener == nil {
+		return nil
+	}
+	return s.listener.Addr()
+}
+
+// Shutdown gracefully stops the HTTP server. In-flight requests are allowed
+// to finish until ctx is cancelled, after which they are forcibly closed.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpSrv.Shutdown(ctx)
+}
+
+// loadToken returns the configured bearer token, preferring AuthTokenFile over
+// AuthToken. The file's contents are trimmed of surrounding whitespace.
+func loadToken(cfg config.APIConfig) (string, error) {
+	if cfg.AuthTokenFile != "" {
+		b, err := os.ReadFile(cfg.AuthTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("api: read auth_token_file %q: %w", cfg.AuthTokenFile, err)
+		}
+		token := strings.TrimSpace(string(b))
+		if token == "" {
+			return "", fmt.Errorf("api: auth_token_file %q is empty", cfg.AuthTokenFile)
+		}
+		return token, nil
+	}
+	if cfg.AuthToken != "" {
+		return cfg.AuthToken, nil
+	}
+	return "", errors.New("api: no auth_token or auth_token_file configured")
+}
+
+// authMW enforces a constant-time bearer-token check on every request.
+func (s *Server) authMW(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "Bearer "
+		h := r.Header.Get("Authorization")
+		if !strings.HasPrefix(h, prefix) {
+			writeError(w, http.StatusUnauthorized, "missing or malformed Authorization header")
+			return
+		}
+		provided := h[len(prefix):]
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(s.token)) != 1 {
+			writeError(w, http.StatusUnauthorized, "invalid token")
+			return
+		}
+		next(w, r)
+	}
+}
+
+// handleList responds with a summary of every active session, sorted newest-first.
+func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {
+	sessionsSnap := s.registry.Snapshot()
+	out := struct {
+		Count    int              `json:"count"`
+		Sessions []sessionSummary `json:"sessions"`
+	}{
+		Count:    len(sessionsSnap),
+		Sessions: make([]sessionSummary, 0, len(sessionsSnap)),
+	}
+	for _, info := range sessionsSnap {
+		out.Sessions = append(out.Sessions, summarize(info))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// handleGet responds with the full metadata for a single session, looked up by
+// session_id (UUID) or server_log_id (base64).
+func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	info, ok := s.registry.Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, detail(info))
+}
+
+// sessionSummary is the per-session record returned by the list endpoint. It
+// pulls a small subset of fields out of the InfoMsgs map for at-a-glance
+// triage; clients needing every field should call the per-session endpoint.
+type sessionSummary struct {
+	SessionID        string    `json:"session_id"`
+	ServerLogID      string    `json:"server_log_id,omitempty"`
+	Mode             string    `json:"mode"`
+	SubmitUser       string    `json:"submituser,omitempty"`
+	SubmitHost       string    `json:"submithost,omitempty"`
+	RunUser          string    `json:"runuser,omitempty"`
+	Command          string    `json:"command,omitempty"`
+	TTYName          string    `json:"ttyname,omitempty"`
+	StartedAt        time.Time `json:"started_at"`
+	SubmitTime       time.Time `json:"submit_time,omitzero"`
+	RemoteAddr       string    `json:"remote_addr,omitempty"`
+	MessagesReceived int64     `json:"messages_received"`
+	LastActivity     time.Time `json:"last_activity,omitzero"`
+}
+
+// sessionDetail is the full per-session record returned by the GET endpoint.
+type sessionDetail struct {
+	SessionID    string         `json:"session_id"`
+	ServerLogID  string         `json:"server_log_id,omitempty"`
+	Mode         string         `json:"mode"`
+	RemoteAddr   string         `json:"remote_addr,omitempty"`
+	StartedAt    time.Time      `json:"started_at"`
+	SubmitTime   time.Time      `json:"submit_time,omitzero"`
+	ExpectIobufs bool           `json:"expect_iobufs"`
+	Info         map[string]any `json:"info"`
+	Live         liveStats      `json:"live"`
+}
+
+type liveStats struct {
+	MessagesReceived int64     `json:"messages_received"`
+	BytesReceived    int64     `json:"bytes_received"`
+	LastActivity     time.Time `json:"last_activity,omitzero"`
+	SessionDir       string    `json:"session_dir,omitempty"`
+	CacheFile        string    `json:"cache_file,omitempty"`
+	Phase            string    `json:"phase,omitempty"`
+}
+
+func summarize(info sessions.SessionInfo) sessionSummary {
+	// The string-typed assertion shorthand returns "" on miss, which is what
+	// the omitempty tags on these fields expect anyway, so no explicit ok-check
+	// is needed.
+	out := sessionSummary{
+		SessionID:   info.SessionID,
+		ServerLogID: info.ServerLogID,
+		Mode:        info.Mode,
+		StartedAt:   info.StartedAt,
+		SubmitTime:  info.SubmitTime,
+		RemoteAddr:  info.RemoteAddr,
+	}
+	out.SubmitUser, _ = info.Info["submituser"].(string)
+	out.SubmitHost, _ = info.Info["submithost"].(string)
+	out.RunUser, _ = info.Info["runuser"].(string)
+	out.Command, _ = info.Info["command"].(string)
+	out.TTYName, _ = info.Info["ttyname"].(string)
+
+	if info.Provider != nil {
+		stats := info.Provider.LiveStats()
+		out.MessagesReceived = stats.MessagesReceived
+		out.LastActivity = stats.LastActivity
+	}
+	return out
+}
+
+func detail(info sessions.SessionInfo) sessionDetail {
+	out := sessionDetail{
+		SessionID:    info.SessionID,
+		ServerLogID:  info.ServerLogID,
+		Mode:         info.Mode,
+		RemoteAddr:   info.RemoteAddr,
+		StartedAt:    info.StartedAt,
+		SubmitTime:   info.SubmitTime,
+		ExpectIobufs: info.ExpectIobufs,
+		Info:         info.Info,
+	}
+	if info.Provider != nil {
+		s := info.Provider.LiveStats()
+		out.Live = liveStats{
+			MessagesReceived: s.MessagesReceived,
+			BytesReceived:    s.BytesReceived,
+			LastActivity:     s.LastActivity,
+			SessionDir:       s.SessionDir,
+			CacheFile:        s.CacheFile,
+			Phase:            s.Phase,
+		}
+	}
+	return out
+}
+
+// writeJSON marshals body into a buffer first so an encoding failure can
+// produce a 500 response instead of a 200 with truncated JSON. Once
+// WriteHeader has fired, the status is locked and the client will see
+// whatever we already wrote.
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		slog.Error("api: failed to encode JSON response", "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}` + "\n"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		slog.Error("api: failed to write JSON response", "error", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,340 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sudosrv/internal/config"
+	"sudosrv/internal/sessions"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type stubProvider struct {
+	stats sessions.LiveStats
+}
+
+func (s *stubProvider) LiveStats() sessions.LiveStats { return s.stats }
+
+func newTestServer(t *testing.T, token string) (*Server, *sessions.Registry) {
+	t.Helper()
+	reg := sessions.NewRegistry()
+	srv, err := NewServer(config.APIConfig{
+		ListenAddress: "127.0.0.1:0",
+		AuthToken:     token,
+	}, reg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, reg
+}
+
+func registerSample(reg *sessions.Registry, sessionID, mode string, info map[string]any, stats sessions.LiveStats) sessions.SessionInfo {
+	si := sessions.SessionInfo{
+		SessionID:    sessionID,
+		ServerLogID:  "logid-" + sessionID,
+		SessionUUID:  uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		Mode:         mode,
+		RemoteAddr:   "10.0.0.5:54321",
+		StartedAt:    time.Date(2026, 4, 30, 14, 22, 11, 0, time.UTC),
+		SubmitTime:   time.Date(2026, 4, 30, 14, 22, 10, 0, time.UTC),
+		ExpectIobufs: true,
+		Info:         info,
+		Provider:     &stubProvider{stats: stats},
+	}
+	reg.Register(si)
+	return si
+}
+
+// withTestServer wires the API server's mux into an httptest.Server so the
+// tests do not have to bind a real port.
+func withTestServer(t *testing.T, srv *Server) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(srv.httpSrv.Handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestNewServer_Validates(t *testing.T) {
+	reg := sessions.NewRegistry()
+	if _, err := NewServer(config.APIConfig{}, reg); err == nil {
+		t.Fatal("expected error for empty ListenAddress")
+	}
+	if _, err := NewServer(config.APIConfig{ListenAddress: "127.0.0.1:0"}, nil); err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+	if _, err := NewServer(config.APIConfig{ListenAddress: "127.0.0.1:0"}, reg); err == nil {
+		t.Fatal("expected error when no token is configured")
+	}
+}
+
+func TestLoadToken_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenPath, []byte("  the-token\n"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	got, err := loadToken(config.APIConfig{AuthTokenFile: tokenPath})
+	if err != nil {
+		t.Fatalf("loadToken: %v", err)
+	}
+	if got != "the-token" {
+		t.Fatalf("loadToken = %q, want %q", got, "the-token")
+	}
+}
+
+func TestLoadToken_EmptyFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenPath, []byte("   \n"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	if _, err := loadToken(config.APIConfig{AuthTokenFile: tokenPath}); err == nil {
+		t.Fatal("expected error for empty token file")
+	}
+}
+
+func TestLoadToken_FilePreferredOverInline(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenPath, []byte("from-file"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	got, err := loadToken(config.APIConfig{AuthTokenFile: tokenPath, AuthToken: "inline"})
+	if err != nil {
+		t.Fatalf("loadToken: %v", err)
+	}
+	if got != "from-file" {
+		t.Fatalf("loadToken = %q, want file value", got)
+	}
+}
+
+func TestAuth_RejectsMissingHeader(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	ts := withTestServer(t, srv)
+
+	resp, err := http.Get(ts.URL + "/api/v1/sessions")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(body["error"], "Authorization") {
+		t.Fatalf("error = %q, want contains \"Authorization\"", body["error"])
+	}
+}
+
+func TestAuth_RejectsWrongScheme(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	ts := withTestServer(t, srv)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestAuth_RejectsWrongToken(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	ts := withTestServer(t, srv)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestAuth_AcceptsCorrectToken(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	ts := withTestServer(t, srv)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestList_EmptyRegistry(t *testing.T) {
+	srv, _ := newTestServer(t, "tok")
+	ts := withTestServer(t, srv)
+
+	body := authedGet(t, ts.URL+"/api/v1/sessions", "tok")
+	var out struct {
+		Count    int              `json:"count"`
+		Sessions []map[string]any `json:"sessions"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Count != 0 {
+		t.Fatalf("count = %d, want 0", out.Count)
+	}
+	if out.Sessions == nil {
+		t.Fatal("sessions field must be a JSON array, even when empty")
+	}
+}
+
+func TestList_PopulatedRegistry(t *testing.T) {
+	srv, reg := newTestServer(t, "tok")
+	ts := withTestServer(t, srv)
+
+	registerSample(reg, "sess-A", "local", map[string]any{
+		"submituser": "alice",
+		"submithost": "host01",
+		"runuser":    "root",
+		"command":    "/usr/bin/vim",
+		"ttyname":    "/dev/pts/3",
+	}, sessions.LiveStats{MessagesReceived: 12, LastActivity: time.Date(2026, 4, 30, 14, 22, 18, 0, time.UTC)})
+
+	body := authedGet(t, ts.URL+"/api/v1/sessions", "tok")
+	var out struct {
+		Count    int              `json:"count"`
+		Sessions []sessionSummary `json:"sessions"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode: %v\nbody=%s", err, body)
+	}
+	if out.Count != 1 || len(out.Sessions) != 1 {
+		t.Fatalf("count=%d sessions=%d, want 1/1", out.Count, len(out.Sessions))
+	}
+	got := out.Sessions[0]
+	if got.SessionID != "sess-A" || got.SubmitUser != "alice" || got.Command != "/usr/bin/vim" {
+		t.Fatalf("unexpected summary: %+v", got)
+	}
+	if got.MessagesReceived != 12 {
+		t.Fatalf("MessagesReceived = %d, want 12", got.MessagesReceived)
+	}
+}
+
+func TestGet_ByUUID(t *testing.T) {
+	srv, reg := newTestServer(t, "tok")
+	ts := withTestServer(t, srv)
+
+	registerSample(reg, "sess-A", "local", map[string]any{
+		"submituser": "alice",
+		"runargv":    []string{"vim", "/etc/hosts"},
+	}, sessions.LiveStats{MessagesReceived: 7, BytesReceived: 1024, SessionDir: "/var/log/x"})
+
+	body := authedGet(t, ts.URL+"/api/v1/sessions/sess-A", "tok")
+	var out sessionDetail
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode: %v\nbody=%s", err, body)
+	}
+	if out.SessionID != "sess-A" {
+		t.Fatalf("SessionID = %q", out.SessionID)
+	}
+	if out.Live.MessagesReceived != 7 || out.Live.BytesReceived != 1024 || out.Live.SessionDir != "/var/log/x" {
+		t.Fatalf("live = %+v", out.Live)
+	}
+	// runargv survives as a JSON array of strings even though the source map
+	// uses []string; the test asserts json round-tripping does not lose shape.
+	got, ok := out.Info["runargv"].([]any)
+	if !ok || len(got) != 2 {
+		t.Fatalf("runargv = %v", out.Info["runargv"])
+	}
+}
+
+func TestGet_ByServerLogID(t *testing.T) {
+	srv, reg := newTestServer(t, "tok")
+	ts := withTestServer(t, srv)
+
+	registerSample(reg, "sess-A", "relay", map[string]any{}, sessions.LiveStats{})
+
+	body := authedGet(t, ts.URL+"/api/v1/sessions/logid-sess-A", "tok")
+	var out sessionDetail
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode: %v\nbody=%s", err, body)
+	}
+	if out.SessionID != "sess-A" {
+		t.Fatalf("SessionID = %q, want sess-A (lookup by ServerLogID)", out.SessionID)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t, "tok")
+	ts := withTestServer(t, srv)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions/missing", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	var body map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["error"] != "session not found" {
+		t.Fatalf("error = %q, want \"session not found\"", body["error"])
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t, "tok")
+	ts := withTestServer(t, srv)
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/v1/sessions", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func authedGet(t *testing.T, url, token string) []byte {
+	t.Helper()
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s status = %d body=%s", url, resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return body
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Server       ServerConfig       `yaml:"server"`
 	Relay        RelayConfig        `yaml:"relay"`
 	LocalStorage LocalStorageConfig `yaml:"local_storage"`
+	API          APIConfig          `yaml:"api"`
 }
 
 // ServerConfig holds server-specific settings.
@@ -40,6 +41,25 @@ type RelayConfig struct {
 	RelayCacheDirectory  string        `yaml:"relay_cache_directory"`
 	ReconnectAttempts    int           `yaml:"reconnect_attempts"`
 	MaxReconnectInterval time.Duration `yaml:"max_reconnect_interval"`
+}
+
+// APIConfig holds settings for the optional management HTTP API. An empty
+// ListenAddress disables the API entirely.
+//
+// Authentication is required when the API is enabled: AuthTokenFile (preferred)
+// points at a file whose contents are the bearer token; AuthToken (discouraged
+// in production) provides the token inline. If both are set, AuthTokenFile
+// wins. Whitespace surrounding a file's contents is trimmed at load time.
+//
+// TLS is optional. When TLSCertFile and TLSKeyFile are set, the API listener
+// terminates TLS using those credentials; otherwise it serves plaintext HTTP
+// (intended for localhost-only deployments).
+type APIConfig struct {
+	ListenAddress string `yaml:"listen_address"`  // empty disables the API
+	AuthToken     string `yaml:"auth_token"`      // inline (discouraged)
+	AuthTokenFile string `yaml:"auth_token_file"` // path to file containing the token (preferred)
+	TLSCertFile   string `yaml:"tls_cert_file"`
+	TLSKeyFile    string `yaml:"tls_key_file"`
 }
 
 // LocalStorageConfig holds settings for local storage mode.
@@ -187,6 +207,14 @@ func Validate(cfg *Config) error {
 	if cfg.Server.Mode == "local" {
 		if err := ValidatePermissions(&cfg.LocalStorage); err != nil {
 			return err
+		}
+	}
+	if cfg.API.ListenAddress != "" {
+		if cfg.API.AuthToken == "" && cfg.API.AuthTokenFile == "" {
+			return fmt.Errorf("api.listen_address is set but neither api.auth_token nor api.auth_token_file is configured")
+		}
+		if (cfg.API.TLSCertFile == "") != (cfg.API.TLSKeyFile == "") {
+			return fmt.Errorf("api.tls_cert_file and api.tls_key_file must both be set or both empty")
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -233,6 +233,58 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "world-writable",
 		},
+		{
+			name: "valid API with inline token",
+			mutate: func(c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthToken = "secret"
+			},
+		},
+		{
+			name: "valid API with token file",
+			mutate: func(c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthTokenFile = "/run/sudosrv/api.token"
+			},
+		},
+		{
+			name: "valid API with TLS",
+			mutate: func(c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthToken = "secret"
+				c.API.TLSCertFile = "api.crt"
+				c.API.TLSKeyFile = "api.key"
+			},
+		},
+		{
+			name: "API enabled without token rejects",
+			mutate: func(c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+			},
+			wantErr: "neither api.auth_token nor api.auth_token_file",
+		},
+		{
+			name: "API TLS cert without key rejects",
+			mutate: func(c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthToken = "secret"
+				c.API.TLSCertFile = "api.crt"
+			},
+			wantErr: "api.tls_cert_file and api.tls_key_file",
+		},
+		{
+			name: "API TLS key without cert rejects",
+			mutate: func(c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthToken = "secret"
+				c.API.TLSKeyFile = "api.key"
+			},
+			wantErr: "api.tls_cert_file and api.tls_key_file",
+		},
+		{
+			name: "API disabled by default",
+			// No mutation: validLocal() leaves API zero-valued. Should not error.
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -14,6 +14,7 @@ import (
 	"sudosrv/internal/metrics"
 	"sudosrv/internal/protocol"
 	"sudosrv/internal/relay"
+	"sudosrv/internal/sessions"
 	"sudosrv/internal/storage"
 	pb "sudosrv/pkg/sudosrv_proto"
 	"sync"
@@ -29,7 +30,10 @@ type Handler struct {
 	config    *config.Config
 	processor protocol.Processor
 	logID     string
+	sessionID string // registry key; matches sessionUUID.String() for new sessions
 	session   SessionHandler
+	registry  *sessions.Registry // optional; nil when the management API is disabled
+	startedAt time.Time          // server-side connection start time
 	isTLS     bool
 	// Rate limiting: token bucket refilled at rateRefillPerSec up to rateBurst.
 	rateTokens     float64
@@ -41,6 +45,25 @@ type Handler struct {
 		newRelaySession        func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig) (SessionHandler, error)
 		newLocalRestartSession func(restartMsg *pb.RestartMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
 	}
+}
+
+// logIDProvider exposes a session's stable base64 log_id for the management
+// registry. storage.Session, storage.EventSession, and relay.Session all
+// implement it; sessions that do not are registered with an empty ServerLogID.
+type logIDProvider interface {
+	LogID() string
+}
+
+// doneNotifier marks a session whose lifecycle outlives the client connection
+// (currently relay sessions, which keep flushing upstream after the client
+// disconnects). Implementers handle their own deregistration via an onDone
+// callback fired from a background goroutine; the connection handler must
+// therefore not deregister them on disconnect, and must guard against the
+// race where IsDone() returns true before registerSession has added the
+// session to the registry — in that case onDone's Deregister was a no-op
+// and the handler must clean up.
+type doneNotifier interface {
+	IsDone() bool
 }
 
 // Rate limiter parameters. A single client connection is allowed to sustain
@@ -56,19 +79,25 @@ type SessionHandler interface {
 	Close() error
 }
 
-// NewHandler creates a new handler for a connection.
+// NewHandler creates a new handler for a connection. The session registry is
+// nil; tests and callers that don't need management-API integration can use
+// this form.
 func NewHandler(conn net.Conn, cfg *config.Config) *Handler {
-	return NewHandlerWithContext(context.Background(), conn, cfg)
+	return NewHandlerWithContext(context.Background(), conn, cfg, nil)
 }
 
-// NewHandlerWithContext creates a new handler for a connection with context support.
-func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Config) *Handler {
+// NewHandlerWithContext creates a new handler for a connection with context
+// support. Pass a non-nil registry to make the connection's session visible to
+// the management API; pass nil to disable that integration.
+func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Config, registry *sessions.Registry) *Handler {
 	_, isTLS := conn.(*tls.Conn)
 	h := &Handler{
 		ctx:            ctx,
 		conn:           conn,
 		config:         cfg,
 		processor:      protocol.NewProcessorWithCloser(conn, conn, conn),
+		registry:       registry,
+		startedAt:      time.Now(),
 		isTLS:          isTLS,
 		rateTokens:     rateBurst,
 		rateLastRefill: time.Now(),
@@ -79,7 +108,15 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 		return storage.NewSession(sessionUUID, acceptMsg, localCfg)
 	}
 	h.sessionFactories.newRelaySession = func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, relayCfg *config.RelayConfig) (SessionHandler, error) {
-		return relay.NewSession(h.ctx, sessionUUID, acceptMsg, relayCfg)
+		// onDone is invoked from the relay's background runner goroutine
+		// after it finishes (including any upstream-flush retries) — not
+		// here at construction time. The connection-side defer skips
+		// deregistering relay sessions for this reason; deregister via
+		// onDone so "phase: flushing" stays visible in the management API
+		// until the flush truly completes.
+		sid := sessionUUID.String()
+		onDone := func() { h.registry.Deregister(sid) }
+		return relay.NewSession(h.ctx, sessionUUID, acceptMsg, relayCfg, onDone)
 	}
 	h.sessionFactories.newLocalRestartSession = func(restartMsg *pb.RestartMessage, localCfg *config.LocalStorageConfig) (SessionHandler, error) {
 		return storage.NewRestartSession(restartMsg, localCfg)
@@ -91,6 +128,15 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 func (h *Handler) Handle() {
 	defer func() {
 		if h.session != nil {
+			// Local sessions are fully closed by Close(); deregister now.
+			// Self-deregistering sessions (relay) own the registry entry's
+			// lifetime via their onDone callback, which fires when their
+			// background flusher exits — possibly long after the connection
+			// closes. Hiding the "phase: flushing" record on disconnect
+			// would defeat the management API's purpose.
+			if _, selfDeregistering := h.session.(doneNotifier); !selfDeregistering && h.registry != nil {
+				h.registry.Deregister(h.sessionID)
+			}
 			metrics.Global.DecrementActiveSessions()
 			if err := h.session.Close(); err != nil {
 				slog.Error("Failed to close session", "error", err, "remote_addr", h.conn.RemoteAddr())
@@ -212,6 +258,94 @@ func (h *Handler) processMessage(clientMsg *pb.ClientMessage) (*pb.ServerMessage
 		slog.Warn("Received unexpected message before session start", "type", fmt.Sprintf("%T", event), "remote_addr", h.conn.RemoteAddr())
 		return &pb.ServerMessage{Type: &pb.ServerMessage_Error{Error: "Protocol error: unexpected message"}}, nil
 	}
+}
+
+// flattenInfoMsgs converts repeated InfoMessage entries into a JSON-friendly
+// map[string]any keyed by InfoMessage.key. Mirrors the per-type switch used
+// when persisting log.json so the management API and the on-disk record carry
+// the same shape.
+func flattenInfoMsgs(infos []*pb.InfoMessage) map[string]any {
+	out := make(map[string]any, len(infos))
+	for _, info := range infos {
+		key := info.GetKey()
+		if key == "" {
+			continue
+		}
+		switch v := info.Value.(type) {
+		case *pb.InfoMessage_Strval:
+			out[key] = v.Strval
+		case *pb.InfoMessage_Numval:
+			out[key] = v.Numval
+		case *pb.InfoMessage_Strlistval:
+			out[key] = v.Strlistval.GetStrings()
+		}
+	}
+	return out
+}
+
+// registerSession adds the just-created session to the registry, if one is
+// configured. Static fields are populated from the AcceptMessage; the live
+// MetadataProvider hook is set when the session implements it. ServerLogID is
+// pulled from the session at register time via the optional logIDProvider
+// interface, so the registered record is complete before any concurrent API
+// reader can observe it.
+func (h *Handler) registerSession(sessionUUID uuid.UUID, mode string, acceptMsg *pb.AcceptMessage) {
+	if h.registry == nil || h.session == nil {
+		return
+	}
+	h.sessionID = sessionUUID.String()
+	info := sessions.SessionInfo{
+		SessionID:    h.sessionID,
+		SessionUUID:  sessionUUID,
+		Mode:         mode,
+		RemoteAddr:   h.conn.RemoteAddr().String(),
+		StartedAt:    h.startedAt,
+		ExpectIobufs: acceptMsg.GetExpectIobufs(),
+		Info:         flattenInfoMsgs(acceptMsg.GetInfoMsgs()),
+	}
+	if st := acceptMsg.GetSubmitTime(); st != nil {
+		info.SubmitTime = time.Unix(st.TvSec, int64(st.TvNsec)).UTC()
+	}
+	if l, ok := h.session.(logIDProvider); ok {
+		info.ServerLogID = l.LogID()
+	}
+	if p, ok := h.session.(sessions.MetadataProvider); ok {
+		info.Provider = p
+	}
+	h.registry.Register(info)
+	// Race protection: if a self-deregistering session's background runner
+	// finished before we registered (e.g. relay cache write failed in
+	// NewSession's goroutine), its onDone callback's Deregister was a no-op
+	// because the registry entry did not yet exist. Detect that and
+	// deregister our just-added entry now.
+	if d, ok := h.session.(doneNotifier); ok && d.IsDone() {
+		h.registry.Deregister(h.sessionID)
+	}
+}
+
+// registerRestartSession is the restart-path equivalent of registerSession.
+// Restart sessions resume an existing log, so the base64 log_id is provided
+// up-front by the client and used as the registry key directly.
+func (h *Handler) registerRestartSession(restartMsg *pb.RestartMessage) {
+	if h.registry == nil || h.session == nil {
+		return
+	}
+	h.sessionID = restartMsg.GetLogId()
+	info := sessions.SessionInfo{
+		SessionID:   h.sessionID,
+		ServerLogID: restartMsg.GetLogId(),
+		Mode:        "local",
+		RemoteAddr:  h.conn.RemoteAddr().String(),
+		StartedAt:   h.startedAt,
+		Info:        map[string]any{"event_type": "restart"},
+	}
+	if rt := restartMsg.GetResumePoint(); rt != nil {
+		info.Info["resume_point"] = time.Unix(rt.TvSec, int64(rt.TvNsec)).UTC().Format(time.RFC3339Nano)
+	}
+	if p, ok := h.session.(sessions.MetadataProvider); ok {
+		info.Provider = p
+	}
+	h.registry.Register(info)
 }
 
 // handleHello responds to a ClientHello.
@@ -396,6 +530,7 @@ func (h *Handler) handleRestart(restartMsg *pb.RestartMessage) (*pb.ServerMessag
 
 	h.session = session
 	h.logID = restartMsg.GetLogId()
+	h.registerRestartSession(restartMsg)
 	metrics.Global.IncrementSessions()
 	metrics.Global.IncrementLocalSessions()
 	slog.Info("Resumed local storage session via restart",
@@ -438,6 +573,7 @@ func (h *Handler) handleAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create local storage session: %w", err)
 		}
+		h.registerSession(sessionUUID, "local", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementLocalSessions()
 		slog.Info("Started local storage session", "log_id", h.logID,
@@ -448,6 +584,7 @@ func (h *Handler) handleAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create relay session: %w", err)
 		}
+		h.registerSession(sessionUUID, "relay", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementRelaySessions()
 		slog.Info("Started relay session", "log_id", h.logID, "upstream", h.config.Relay.UpstreamHost,
@@ -458,7 +595,9 @@ func (h *Handler) handleAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, 
 	}
 
 	// The first message to the session handler is the AcceptMessage itself
-	// to allow it to initialize and send back the initial log_id.
+	// to allow it to initialize and send back the initial log_id. The log_id
+	// is also captured at registerSession time via the logIDProvider getter,
+	// so we don't need to update the registry on the response.
 	return h.session.HandleClientMessage(&pb.ClientMessage{Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: acceptMsg}})
 }
 
@@ -472,6 +611,7 @@ func (h *Handler) handleEventOnlyAccept(sessionUUID uuid.UUID, acceptMsg *pb.Acc
 			return nil, fmt.Errorf("failed to create local event-only session: %w", err)
 		}
 		h.session = session
+		h.registerSession(sessionUUID, "local", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementLocalSessions()
 		slog.Info("Started local event-only session", "log_id", h.logID,
@@ -482,6 +622,7 @@ func (h *Handler) handleEventOnlyAccept(sessionUUID uuid.UUID, acceptMsg *pb.Acc
 			return nil, fmt.Errorf("failed to create relay event-only session: %w", err)
 		}
 		h.session = session
+		h.registerSession(sessionUUID, "relay", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementRelaySessions()
 		slog.Info("Started relay event-only session", "log_id", h.logID, "upstream", h.config.Relay.UpstreamHost,

--- a/internal/connection/handler_test.go
+++ b/internal/connection/handler_test.go
@@ -2,12 +2,14 @@
 package connection
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"os"
 	"path/filepath"
 	"sudosrv/internal/config"
 	"sudosrv/internal/protocol"
+	"sudosrv/internal/sessions"
 	pb "sudosrv/pkg/sudosrv_proto"
 	"sync"
 	"testing"
@@ -1052,4 +1054,88 @@ func TestSetOrUpdateInfoMessage_UpdateExisting(t *testing.T) {
 	if count != 1 {
 		t.Errorf("Expected exactly 1 'existing' info message, got %d", count)
 	}
+}
+
+// fakeDoneRelaySession implements SessionHandler plus the doneNotifier and
+// logIDProvider markers. It pretends to be a relay session whose background
+// runner has already exited (IsDone returns true) and has already fired its
+// onDone callback before the connection handler called registerSession.
+type fakeDoneRelaySession struct{}
+
+func (fakeDoneRelaySession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
+	if msg.GetAcceptMsg() != nil {
+		return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: "fake-log-id"}}, nil
+	}
+	return nil, nil
+}
+func (fakeDoneRelaySession) Close() error  { return nil }
+func (fakeDoneRelaySession) IsDone() bool  { return true }
+func (fakeDoneRelaySession) LogID() string { return "fake-log-id" }
+
+// TestRelay_DoneBeforeRegisterDoesNotOrphan reproduces the race the codex
+// adversarial review flagged: a relay session's background runner exits and
+// fires onDone before registerSession adds the entry, leaving an orphan
+// registry record that the connection-close path then never cleans up
+// (because relay sessions are skipped by the disconnect-time deregister).
+// The fix detects an already-done session immediately after register and
+// removes the entry inside registerSession.
+func TestRelay_DoneBeforeRegisterDoesNotOrphan(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Mode:        "relay",
+			IdleTimeout: 1 * time.Second,
+			ServerID:    "TestSrv",
+		},
+		Relay: config.RelayConfig{
+			UpstreamHost:        "127.0.0.1:0",
+			RelayCacheDirectory: t.TempDir(),
+		},
+	}
+
+	registry := sessions.NewRegistry()
+	handler := NewHandlerWithContext(context.Background(), serverConn, cfg, registry)
+	handler.sessionFactories.newRelaySession = func(sessionUUID uuid.UUID, _ *pb.AcceptMessage, _ *config.RelayConfig) (SessionHandler, error) {
+		// Simulate the race: the runner finished and called Deregister
+		// before registerSession had a chance to add the entry. The
+		// Deregister here is a no-op because the entry does not yet
+		// exist — this is exactly the orphan-producing situation.
+		registry.Deregister(sessionUUID.String())
+		return fakeDoneRelaySession{}, nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(handler.Handle)
+
+	clientProc := protocol.NewProcessor(clientConn, clientConn)
+	if err := clientProc.WriteClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_AcceptMsg{
+			AcceptMsg: &pb.AcceptMessage{
+				SubmitTime:   &pb.TimeSpec{TvSec: 1700000000, TvNsec: 0},
+				ExpectIobufs: true,
+				InfoMsgs: []*pb.InfoMessage{
+					{Key: "submituser", Value: &pb.InfoMessage_Strval{Strval: "alice"}},
+					{Key: "submithost", Value: &pb.InfoMessage_Strval{Strval: "host01"}},
+					{Key: "runuser", Value: &pb.InfoMessage_Strval{Strval: "root"}},
+					{Key: "command", Value: &pb.InfoMessage_Strval{Strval: "/bin/id"}},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("client write AcceptMsg: %v", err)
+	}
+	// Wait for the LogId response. By the time it arrives, registerSession
+	// has finished (it runs before HandleClientMessage in handleAccept).
+	if _, err := clientProc.ReadServerMessage(); err != nil {
+		t.Fatalf("client read LogId: %v", err)
+	}
+
+	if got := registry.Len(); got != 0 {
+		t.Fatalf("registry should be empty after done-before-register cleanup; len=%d", got)
+	}
+
+	serverConn.Close()
+	wg.Wait()
 }

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -17,8 +17,10 @@ import (
 	"path/filepath"
 	"sudosrv/internal/config"
 	"sudosrv/internal/protocol"
+	"sudosrv/internal/sessions"
 	pb "sudosrv/pkg/sudosrv_proto"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,8 +32,22 @@ const (
 	// FlushingSuffix is appended to a cache file while it is being flushed upstream.
 	// Exported so startup orphan recovery can identify mid-flush files.
 	FlushingSuffix = ".flushing"
+	// DeliveredSuffix is appended to a cache file whose contents have been
+	// flushed upstream but which we could not Remove (e.g. permission or IO
+	// error). Orphan recovery globs *.log and *.log.flushing, so files with
+	// this suffix are invisible to it — preventing the duplicate-upstream
+	// hazard that would arise from re-flushing already-delivered messages.
+	DeliveredSuffix = ".delivered"
 	// commitPointInterval matches C sudo_logsrvd's ACK_FREQUENCY (10 seconds).
 	commitPointInterval = 10 * time.Second
+)
+
+// Phase strings exposed via Session.LiveStats. Stored as package-level vars
+// because atomic.Pointer[string] requires a pointer; using `const` here would
+// not let us take an address.
+var (
+	phaseWriting  = "writing"
+	phaseFlushing = "flushing"
 )
 
 // Session handles the entire lifecycle of a relay session. It is a durable,
@@ -49,12 +65,38 @@ type Session struct {
 	lastCommitTime   time.Time                // When last commit point was sent to client
 	ctx              context.Context
 	cancel           context.CancelFunc
+	// onDone is invoked exactly once after the background runner exits — i.e.
+	// after both the cache-write phase and any upstream-flush phase finish.
+	// Connection-side bookkeeping that needs to outlive the client connection
+	// (such as session-registry deregistration) hooks into this.
+	onDone func()
+	// done is set to true before onDone fires so callers racing with the
+	// runner can detect a "done before I got here" outcome and run any
+	// cleanup that onDone could not (because the resource it would clean
+	// up did not yet exist when onDone ran).
+	done atomic.Bool
+	// Live stats exposed to the management API.
+	msgCount      atomic.Int64
+	bytesReceived atomic.Int64
+	lastActivity  atomic.Pointer[time.Time]
+	phase         atomic.Pointer[string] // "writing" -> "flushing"
 }
+
+// IsDone reports whether the background runner has finished. Once true the
+// session will never call its onDone callback again; any registry or other
+// state that was added after onDone fired must be cleaned up by the caller.
+func (s *Session) IsDone() bool { return s.done.Load() }
 
 // NewSession creates a new relay session handler.
 // The provided ctx is used as the parent context; cancelling it will stop the
 // session's background goroutine after the current operation completes.
-func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig) (*Session, error) {
+//
+// onDone (if non-nil) is invoked exactly once after the background runner
+// finishes, including any upstream-flush retries. This lets callers tie
+// resources whose lifecycle exceeds the client connection (e.g. management
+// API registry entries) to the actual end of the session rather than the end
+// of the connection.
+func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig, onDone func()) (*Session, error) {
 	if err := os.MkdirAll(cfg.RelayCacheDirectory, 0750); err != nil {
 		return nil, fmt.Errorf("could not create relay cache directory %s: %w", cfg.RelayCacheDirectory, err)
 	}
@@ -76,7 +118,9 @@ func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.Accept
 		cumulativeDelay:  make(map[string]time.Duration),
 		ctx:              ctx,
 		cancel:           cancel,
+		onDone:           onDone,
 	}
+	s.phase.Store(&phaseWriting)
 
 	s.wg.Add(1)
 	go s.run() // Start the single, durable goroutine for this session.
@@ -90,6 +134,16 @@ func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.Accept
 func (s *Session) run() {
 	defer s.wg.Done()
 	defer s.cancel()
+	defer func() {
+		// Set done=true before firing onDone so any caller that observes
+		// IsDone() returning true after we have called onDone can rely on
+		// onDone having already run (i.e. its Deregister either happened or
+		// was a no-op because the registry entry did not yet exist).
+		s.done.Store(true)
+		if s.onDone != nil {
+			s.onDone()
+		}
+	}()
 	slog.Debug("Relay session runner started", "log_id", s.logID)
 
 	// Phase 1: Write all incoming messages to the local cache file.
@@ -101,6 +155,7 @@ func (s *Session) run() {
 	}
 
 	// Phase 2: The client session is complete. Now, persistently try to flush the file.
+	s.phase.Store(&phaseFlushing)
 	slog.Info("Client session complete, beginning persistent flush attempts.", "log_id", s.logID, "file", s.cacheFileName)
 	for attempt := 0; s.config.ReconnectAttempts == -1 || attempt < s.config.ReconnectAttempts; attempt++ {
 		select {
@@ -157,10 +212,15 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 		return
 	}
 	defer func() {
+		// Sync surfaces fsync-time errors; Close surfaces flush errors that
+		// only manifest at close (e.g. NFS or disk-full). Drop neither — a
+		// cache file that fails to close cleanly is a data-loss signal.
 		if err := file.Sync(); err != nil {
 			slog.Error("Failed to fsync relay cache file", "log_id", s.logID, "error", err)
 		}
-		file.Close()
+		if err := file.Close(); err != nil {
+			slog.Error("Failed to close relay cache file", "log_id", s.logID, "error", err)
+		}
 	}()
 
 	// Write the essential AcceptMessage first to ensure the cache file is valid for flushing.
@@ -236,7 +296,32 @@ func extractIoDelay(msg *pb.ClientMessage) (string, *pb.TimeSpec, bool) {
 	}
 }
 
+// LogID returns the base64-encoded sudo log_id assigned when the relay session
+// was created. It is stable for the lifetime of the session.
+func (s *Session) LogID() string { return s.logID }
+
+// LiveStats returns a snapshot of mutable counters for the management API.
+func (s *Session) LiveStats() sessions.LiveStats {
+	stats := sessions.LiveStats{
+		MessagesReceived: s.msgCount.Load(),
+		BytesReceived:    s.bytesReceived.Load(),
+		CacheFile:        s.cacheFileName,
+	}
+	if t := s.lastActivity.Load(); t != nil {
+		stats.LastActivity = *t
+	}
+	if p := s.phase.Load(); p != nil {
+		stats.Phase = *p
+	}
+	return stats
+}
+
 func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
+	s.msgCount.Add(1)
+	s.bytesReceived.Add(int64(proto.Size(msg)))
+	now := time.Now()
+	s.lastActivity.Store(&now)
+
 	// Don't process the initial AcceptMsg again, it was handled in NewSession.
 	if _, ok := msg.Type.(*pb.ClientMessage_AcceptMsg); ok {
 		// For relay mode, we return a log ID immediately to satisfy the client
@@ -405,6 +490,33 @@ func FlushOrphanedFile(ctx context.Context, filePath string, cfg *config.RelayCo
 	return nil
 }
 
+// retireCacheFile is called after flushFile finishes sending a cache file's
+// contents upstream. It removes the file. If Remove fails, the file is
+// renamed to DeliveredSuffix so orphan recovery cannot re-flush it on next
+// startup — re-flushing already-delivered messages would duplicate audit
+// records upstream, which is worse than leaking a stale on-disk file.
+func retireCacheFile(filePath string) {
+	err := os.Remove(filePath)
+	if err == nil {
+		return
+	}
+	delivered := filePath + DeliveredSuffix
+	if renameErr := os.Rename(filePath, delivered); renameErr != nil {
+		slog.Error(
+			"Failed to retire flushed cache file; orphan recovery may re-flush and duplicate upstream records",
+			"path", filePath,
+			"remove_error", err,
+			"rename_error", renameErr,
+		)
+		return
+	}
+	slog.Warn(
+		"Could not remove flushed cache file; renamed to sentinel to prevent re-flush",
+		"path", delivered,
+		"remove_error", err,
+	)
+}
+
 func flushFile(ctx context.Context, proc protocol.Processor, filePath string, cfg *config.RelayConfig) error {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -415,21 +527,17 @@ func flushFile(ctx context.Context, proc protocol.Processor, filePath string, cf
 	for {
 		msg, err := readProtoMessage(f)
 		if errors.Is(err, io.EOF) {
-			// All messages sent successfully — now safe to remove the cache file
-			if removeErr := os.Remove(filePath); removeErr != nil {
-				slog.Error("Failed to remove flushed cache file", "path", filePath, "error", removeErr)
-			}
+			// All messages sent successfully — retire the cache file.
+			retireCacheFile(filePath)
 			return nil
 		}
 		if errors.Is(err, io.ErrUnexpectedEOF) {
 			// Truncated tail (e.g., crash mid-write). Treat as end-of-stream for
-			// flush purposes so the file can be removed and recovery doesn't loop
+			// flush purposes so the file can be retired and recovery doesn't loop
 			// forever on corrupt trailing bytes.
 			slog.Warn("Cache file has truncated trailing record; flushing what was read",
 				"path", filePath, "error", err)
-			if removeErr := os.Remove(filePath); removeErr != nil {
-				slog.Error("Failed to remove flushed cache file", "path", filePath, "error", removeErr)
-			}
+			retireCacheFile(filePath)
 			return nil
 		}
 		if err != nil {

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -187,7 +187,7 @@ func TestRelaySession_CacheAndFlush(t *testing.T) {
 	acceptMsg := createTestAcceptMessage()
 
 	// 3. Create a new relay session
-	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg)
+	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestRelayCommitPoints(t *testing.T) {
 	sessionUUID := uuid.MustParse("b2c3d4e5-f6a7-4b2c-9d3e-0f1a2b3c4d5e")
 	acceptMsg := createTestAcceptMessage()
 
-	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg)
+	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestRelayCommitPointThrottling(t *testing.T) {
 	sessionUUID := uuid.MustParse("c3d4e5f6-a7b8-4c3d-ae4f-1a2b3c4d5e6f")
 	acceptMsg := createTestAcceptMessage()
 
-	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg)
+	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -412,7 +412,7 @@ func TestRelaySession_CloseDoesNotWaitForFlush(t *testing.T) {
 	}
 
 	sessionUUID := uuid.MustParse("d4e5f6a7-b8c9-4d5e-af60-2b3c4d5e6f70")
-	session, err := NewSession(ctx, sessionUUID, createTestAcceptMessage(), relayCfg)
+	session, err := NewSession(ctx, sessionUUID, createTestAcceptMessage(), relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}

--- a/internal/server/api_e2e_test.go
+++ b/internal/server/api_e2e_test.go
@@ -1,0 +1,389 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sudosrv/internal/config"
+	"sudosrv/internal/protocol"
+	pb "sudosrv/pkg/sudosrv_proto"
+	"testing"
+	"time"
+)
+
+// TestAPI_EndToEnd starts a real server with both the protocol listener and
+// the management API enabled, drives an AcceptMessage through the protocol
+// path, queries the API to see the session, then closes the client connection
+// and asserts the session is gone.
+func TestAPI_EndToEnd(t *testing.T) {
+	apiAddr := freeAddr(t)
+	srv := newTestServer(t, &config.Config{
+		Server: config.ServerConfig{
+			Mode:          "local",
+			ListenAddress: "127.0.0.1:0",
+			IdleTimeout:   30 * time.Second,
+		},
+		LocalStorage: config.LocalStorageConfig{
+			LogDirectory:    t.TempDir(),
+			DirPermissions:  0750,
+			FilePermissions: 0640,
+		},
+		API: config.APIConfig{
+			ListenAddress: apiAddr,
+			AuthToken:     "secret",
+		},
+	})
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { shutdown(srv) })
+
+	if srv.apiServer == nil {
+		t.Fatal("apiServer is nil after Start with API config")
+	}
+
+	// Wait for the API listener to actually bind. The API server's Start runs
+	// asynchronously; poll briefly until a 401 (auth failure) round-trips.
+	apiURL := "http://" + apiAddr
+	if err := waitForAPI(apiURL); err != nil {
+		t.Fatalf("API not ready: %v", err)
+	}
+
+	// Open a protocol-level connection and drive a full AcceptMessage through.
+	protoAddr := srv.listeners[0].Addr().String()
+	conn, err := net.Dial("tcp", protoAddr)
+	if err != nil {
+		t.Fatalf("Dial protocol: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	proc := protocol.NewProcessorWithCloser(conn, conn, conn)
+
+	// Step 1: ClientHello
+	if err := proc.WriteClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_HelloMsg{HelloMsg: &pb.ClientHello{ClientId: "e2e-test"}},
+	}); err != nil {
+		t.Fatalf("write ClientHello: %v", err)
+	}
+	resp, err := proc.ReadServerMessage()
+	if err != nil {
+		t.Fatalf("read ServerHello: %v", err)
+	}
+	if resp.GetHello() == nil {
+		t.Fatalf("expected ServerHello, got %T", resp.GetType())
+	}
+
+	// Step 2: AcceptMessage with the minimum required InfoMsgs.
+	acceptMsg := &pb.AcceptMessage{
+		SubmitTime:   &pb.TimeSpec{TvSec: time.Now().Unix()},
+		ExpectIobufs: true,
+		InfoMsgs: []*pb.InfoMessage{
+			strInfo("submituser", "alice"),
+			strInfo("submithost", "host01"),
+			strInfo("runuser", "root"),
+			strInfo("command", "/usr/bin/vim"),
+			strInfo("ttyname", "/dev/pts/3"),
+			strInfo("submitcwd", "/home/alice"),
+		},
+	}
+	if err := proc.WriteClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: acceptMsg},
+	}); err != nil {
+		t.Fatalf("write AcceptMessage: %v", err)
+	}
+	resp, err = proc.ReadServerMessage()
+	if err != nil {
+		t.Fatalf("read LogId response: %v", err)
+	}
+	logID := resp.GetLogId()
+	if logID == "" {
+		t.Fatalf("expected LogId response, got %T", resp.GetType())
+	}
+
+	// Step 3: Hit the API and verify the session shows up.
+	sessions := listSessionsViaAPI(t, apiURL+"/api/v1/sessions", "secret")
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 active session, got %d: %+v", len(sessions), sessions)
+	}
+	got := sessions[0]
+	if got["mode"] != "local" {
+		t.Errorf("mode = %v, want local", got["mode"])
+	}
+	if got["submituser"] != "alice" {
+		t.Errorf("submituser = %v, want alice", got["submituser"])
+	}
+	if got["command"] != "/usr/bin/vim" {
+		t.Errorf("command = %v, want /usr/bin/vim", got["command"])
+	}
+	if got["server_log_id"] != logID {
+		t.Errorf("server_log_id = %v, want %q", got["server_log_id"], logID)
+	}
+
+	// Step 4: GET by session_id should also work.
+	sessionID, _ := got["session_id"].(string)
+	if sessionID == "" {
+		t.Fatal("session_id missing in API response")
+	}
+	detail := getSessionViaAPI(t, apiURL+"/api/v1/sessions/"+sessionID, "secret")
+	if detail["session_id"] != sessionID {
+		t.Errorf("detail session_id = %v, want %q", detail["session_id"], sessionID)
+	}
+
+	// Step 5: GET by server_log_id should also work. The base64 log_id may
+	// contain "/" so the URL segment must be escaped before issuing the request.
+	detail2 := getSessionViaAPI(t, apiURL+"/api/v1/sessions/"+url.PathEscape(logID), "secret")
+	if detail2["session_id"] != sessionID {
+		t.Errorf("lookup by ServerLogID: session_id = %v, want %q", detail2["session_id"], sessionID)
+	}
+
+	// Step 6: Close the client connection. The server-side Handle() defer
+	// deregisters the session.
+	_ = conn.Close()
+
+	// Wait briefly for the deregister to land. We retry rather than sleep a
+	// fixed duration so the test stays fast on healthy systems.
+	if err := waitFor(func() bool {
+		return len(listSessionsViaAPI(t, apiURL+"/api/v1/sessions", "secret")) == 0
+	}, 2*time.Second); err != nil {
+		t.Fatalf("session was not deregistered: %v", err)
+	}
+
+	// Step 7: GET on a now-vanished session should return 404.
+	resp404 := apiRequest(t, apiURL+"/api/v1/sessions/"+sessionID, "secret")
+	if resp404.StatusCode != http.StatusNotFound {
+		t.Errorf("after deregister: GET status = %d, want 404", resp404.StatusCode)
+	}
+	resp404.Body.Close()
+}
+
+// TestAPI_RelayVisibleDuringFlush asserts that a relay session whose client
+// connection has closed remains visible in the management API while its
+// background goroutine is still attempting upstream flushes. Hiding it on
+// disconnect would defeat the API's purpose for relay-mode operators trying
+// to diagnose store-and-forward backlogs.
+func TestAPI_RelayVisibleDuringFlush(t *testing.T) {
+	apiAddr := freeAddr(t)
+	// Pick a free port for the upstream and immediately close the listener so
+	// dial attempts get a connection-refused error. The relay session will
+	// enter the flushing phase and retry with exponential backoff.
+	upstreamAddr := freeAddr(t)
+
+	srv := newTestServer(t, &config.Config{
+		Server: config.ServerConfig{
+			Mode:          "relay",
+			ListenAddress: "127.0.0.1:0",
+			IdleTimeout:   30 * time.Second,
+		},
+		Relay: config.RelayConfig{
+			UpstreamHost:         upstreamAddr,
+			ConnectTimeout:       500 * time.Millisecond,
+			RelayCacheDirectory:  t.TempDir(),
+			ReconnectAttempts:    -1,             // infinite — we cancel via shutdown
+			MaxReconnectInterval: 5 * time.Second,
+		},
+		API: config.APIConfig{
+			ListenAddress: apiAddr,
+			AuthToken:     "secret",
+		},
+	})
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { shutdown(srv) })
+
+	apiURL := "http://" + apiAddr
+	if err := waitForAPI(apiURL); err != nil {
+		t.Fatalf("API not ready: %v", err)
+	}
+
+	// Drive a full relay session: ClientHello, AcceptMessage, ExitMessage.
+	conn, err := net.Dial("tcp", srv.listeners[0].Addr().String())
+	if err != nil {
+		t.Fatalf("Dial protocol: %v", err)
+	}
+	proc := protocol.NewProcessorWithCloser(conn, conn, conn)
+
+	if err := proc.WriteClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_HelloMsg{HelloMsg: &pb.ClientHello{ClientId: "e2e-relay"}},
+	}); err != nil {
+		t.Fatalf("write ClientHello: %v", err)
+	}
+	if _, err := proc.ReadServerMessage(); err != nil {
+		t.Fatalf("read ServerHello: %v", err)
+	}
+
+	acceptMsg := &pb.AcceptMessage{
+		SubmitTime:   &pb.TimeSpec{TvSec: time.Now().Unix()},
+		ExpectIobufs: true,
+		InfoMsgs: []*pb.InfoMessage{
+			strInfo("submituser", "alice"),
+			strInfo("submithost", "host01"),
+			strInfo("runuser", "root"),
+			strInfo("command", "/usr/bin/vim"),
+			strInfo("submitcwd", "/home/alice"),
+		},
+	}
+	if err := proc.WriteClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: acceptMsg},
+	}); err != nil {
+		t.Fatalf("write AcceptMessage: %v", err)
+	}
+	if _, err := proc.ReadServerMessage(); err != nil {
+		t.Fatalf("read LogId response: %v", err)
+	}
+
+	// Send ExitMessage so the relay session moves into the flush phase.
+	if err := proc.WriteClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_ExitMsg{ExitMsg: &pb.ExitMessage{ExitValue: 0}},
+	}); err != nil {
+		t.Fatalf("write ExitMessage: %v", err)
+	}
+	// Close the connection. The relay session's background goroutine keeps
+	// running because the upstream is unreachable.
+	_ = conn.Close()
+
+	// Wait for the session to enter the flushing phase. The connection's
+	// teardown does not deregister relay sessions, so the entry must remain.
+	if err := waitFor(func() bool {
+		ss := listSessionsViaAPI(t, apiURL+"/api/v1/sessions", "secret")
+		if len(ss) != 1 {
+			return false
+		}
+		s, _ := ss[0]["session_id"].(string)
+		if s == "" {
+			return false
+		}
+		got := getSessionViaAPI(t, apiURL+"/api/v1/sessions/"+s, "secret")
+		live, _ := got["live"].(map[string]any)
+		phase, _ := live["phase"].(string)
+		return phase == "flushing"
+	}, 5*time.Second); err != nil {
+		t.Fatalf("relay session never reached phase=flushing in API: %v", err)
+	}
+
+	// Confirm the summary call also shows the session with mode=relay.
+	ss := listSessionsViaAPI(t, apiURL+"/api/v1/sessions", "secret")
+	if len(ss) != 1 {
+		t.Fatalf("expected 1 active session in flushing phase, got %d", len(ss))
+	}
+	if ss[0]["mode"] != "relay" {
+		t.Errorf("mode = %v, want relay", ss[0]["mode"])
+	}
+
+	// shutdown() cancels the server context, which propagates into the relay
+	// session's run() and unblocks its retry loop. onDone then deregisters.
+}
+
+// TestAPI_DisabledByDefault confirms that an empty APIConfig produces no API
+// listener and no extra goroutines.
+func TestAPI_DisabledByDefault(t *testing.T) {
+	srv := newTestServer(t, &config.Config{
+		Server: config.ServerConfig{
+			Mode:          "local",
+			ListenAddress: "127.0.0.1:0",
+		},
+		LocalStorage: config.LocalStorageConfig{
+			LogDirectory:    t.TempDir(),
+			DirPermissions:  0750,
+			FilePermissions: 0640,
+		},
+	})
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer shutdown(srv)
+	if srv.apiServer != nil {
+		t.Fatal("apiServer is non-nil when APIConfig is empty")
+	}
+}
+
+func strInfo(key, val string) *pb.InfoMessage {
+	return &pb.InfoMessage{Key: key, Value: &pb.InfoMessage_Strval{Strval: val}}
+}
+
+// freeAddr asks the kernel for a free TCP port and immediately closes the
+// listener. There is a small race window where another process can bind the
+// same port before we do, but the API server's bind error would surface in
+// the test as an explicit failure.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
+}
+
+func waitForAPI(url string) error {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url + "/api/v1/sessions")
+		if err == nil {
+			resp.Body.Close()
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("API never accepted connections at %s", url)
+}
+
+func waitFor(cond func() bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("condition not met within %s", timeout)
+}
+
+func apiRequest(t *testing.T, url, token string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	return resp
+}
+
+func listSessionsViaAPI(t *testing.T, url, token string) []map[string]any {
+	t.Helper()
+	resp := apiRequest(t, url, token)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s status = %d body=%s", url, resp.StatusCode, body)
+	}
+	var out struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out.Sessions
+}
+
+func getSessionViaAPI(t *testing.T, url, token string) map[string]any {
+	t.Helper()
+	resp := apiRequest(t, url, token)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s status = %d body=%s", url, resp.StatusCode, body)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,15 +4,19 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"sudosrv/internal/api"
 	"sudosrv/internal/config"
 	"sudosrv/internal/connection"
 	"sudosrv/internal/metrics"
 	"sudosrv/internal/relay"
+	"sudosrv/internal/sessions"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -31,6 +35,12 @@ type Server struct {
 	// connSem is a counting semaphore that caps the number of concurrent client
 	// connections. nil when unbounded (MaxConnections <= 0).
 	connSem chan struct{}
+	// registry tracks active sessions for the optional management API. Always
+	// non-nil; reads from a disabled API simply never occur.
+	registry *sessions.Registry
+	// apiServer is the optional management HTTP server. nil when the API is
+	// disabled in config.
+	apiServer *api.Server
 }
 
 // NewServer creates a new server instance.
@@ -44,6 +54,7 @@ func NewServer(cfg *config.Config, configPath string, logLevel *slog.LevelVar) (
 		listeners:  make([]net.Listener, 0),
 		ctx:        ctx,
 		cancel:     cancel,
+		registry:   sessions.NewRegistry(),
 	}
 	s.config.Store(cfg)
 	if max := cfg.Server.MaxConnections; max > 0 {
@@ -52,23 +63,24 @@ func NewServer(cfg *config.Config, configPath string, logLevel *slog.LevelVar) (
 	return s, nil
 }
 
-// Start initializes listeners and begins accepting connections.
+// Start initializes listeners and begins accepting connections. It is
+// transactional: every listener (protocol plaintext, protocol TLS, management
+// API) is bound synchronously before any accept or serve goroutine is
+// spawned. A late bind failure (e.g. management API port already in use)
+// therefore cannot leak side effects from a protocol accept loop that had
+// already begun handing connections to the session pipeline.
 func (s *Server) Start() error {
 	cfg := s.config.Load()
 
-	// Start plaintext listener if configured
+	// Phase 1: bind every required listener.
 	if cfg.Server.ListenAddress != "" {
 		plainListener, err := net.Listen("tcp", cfg.Server.ListenAddress)
 		if err != nil {
 			return fmt.Errorf("failed to start plaintext listener on %s: %w", cfg.Server.ListenAddress, err)
 		}
 		s.listeners = append(s.listeners, plainListener)
-		s.waitGroup.Add(1)
-		go s.acceptLoop(plainListener)
-		slog.Info("Started plaintext listener", "address", cfg.Server.ListenAddress)
 	}
 
-	// Start TLS listener if configured
 	if cfg.Server.ListenAddressTLS != "" {
 		if cfg.Server.TLSCertFile == "" || cfg.Server.TLSKeyFile == "" {
 			s.closeListeners()
@@ -83,28 +95,62 @@ func (s *Server) Start() error {
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS13,
 		}
-
 		tlsListener, err := tls.Listen("tcp", cfg.Server.ListenAddressTLS, tlsConfig)
 		if err != nil {
 			s.closeListeners()
 			return fmt.Errorf("failed to start TLS listener on %s: %w", cfg.Server.ListenAddressTLS, err)
 		}
 		s.listeners = append(s.listeners, tlsListener)
-		s.waitGroup.Add(1)
-		go s.acceptLoop(tlsListener)
-		slog.Info("Started TLS listener", "address", cfg.Server.ListenAddressTLS)
 	}
 
 	if len(s.listeners) == 0 {
 		return fmt.Errorf("no listeners configured, server not started")
 	}
 
-	// Start metrics logging goroutine
+	if cfg.API.ListenAddress != "" {
+		apiSrv, err := api.NewServer(cfg.API, s.registry)
+		if err != nil {
+			s.closeListeners()
+			return fmt.Errorf("failed to create management API: %w", err)
+		}
+		if err := apiSrv.Listen(); err != nil {
+			s.closeListeners()
+			return fmt.Errorf("failed to start management API: %w", err)
+		}
+		s.apiServer = apiSrv
+	}
+
+	// Phase 2: every listener is bound — start serving.
+	plaintextAddr := cfg.Server.ListenAddress
+	tlsAddr := cfg.Server.ListenAddressTLS
+	for _, l := range s.listeners {
+		s.waitGroup.Add(1)
+		go s.acceptLoop(l)
+	}
+	if plaintextAddr != "" {
+		slog.Info("Started plaintext listener", "address", plaintextAddr)
+	}
+	if tlsAddr != "" {
+		slog.Info("Started TLS listener", "address", tlsAddr)
+	}
+	if s.apiServer != nil {
+		s.waitGroup.Add(1)
+		go func() {
+			defer s.waitGroup.Done()
+			if err := s.apiServer.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				slog.Error("Management API server exited with error", "error", err)
+			}
+		}()
+		slog.Info("Started management API",
+			"address", s.apiServer.Addr(),
+			"tls", cfg.API.TLSCertFile != "")
+	}
+
+	// Phase 3: ancillary goroutines under the server's lifecycle so shutdown
+	// cancels them cleanly.
 	s.waitGroup.Add(1)
 	go s.logMetricsPeriodically()
 
-	// Kick off orphan recovery for relay mode under the server's lifecycle
-	// so shutdown cancels any in-flight flush and waits for it to unwind.
 	if cfg.Server.Mode == "relay" {
 		s.waitGroup.Add(1)
 		go func() {
@@ -185,7 +231,7 @@ func (s *Server) acceptLoop(listener net.Listener) {
 				metrics.Global.DecrementActiveConnections()
 			}()
 			slog.Debug("Starting connection handler", "remote_addr", conn.RemoteAddr())
-			handler := connection.NewHandlerWithContext(s.ctx, conn, s.config.Load())
+			handler := connection.NewHandlerWithContext(s.ctx, conn, s.config.Load(), s.registry)
 			handler.Handle()
 			slog.Debug("Connection handler finished", "remote_addr", conn.RemoteAddr())
 		}()
@@ -213,6 +259,17 @@ func (s *Server) Wait() {
 
 	// Cancel context to signal all goroutines to stop
 	s.cancel()
+
+	// Stop the management API first so callers see a clean refusal rather than
+	// a stale snapshot of sessions that are about to tear down. http.Server.Shutdown
+	// drains in-flight requests but stops accepting new ones immediately.
+	if s.apiServer != nil {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := s.apiServer.Shutdown(shutCtx); err != nil {
+			slog.Error("Management API shutdown error", "error", err)
+		}
+		cancel()
+	}
 
 	// Close all listeners to unblock acceptLoop
 	for _, l := range s.listeners {
@@ -283,6 +340,16 @@ func restartRequiredReloadChange(oldCfg, newCfg *config.Config) string {
 		return "server.tls_key_file changed"
 	case oldCfg.Server.MaxConnections != newCfg.Server.MaxConnections:
 		return fmt.Sprintf("server.max_connections changed from %d to %d", oldCfg.Server.MaxConnections, newCfg.Server.MaxConnections)
+	case oldCfg.API.ListenAddress != newCfg.API.ListenAddress:
+		return fmt.Sprintf("api.listen_address changed from %q to %q", oldCfg.API.ListenAddress, newCfg.API.ListenAddress)
+	case oldCfg.API.AuthToken != newCfg.API.AuthToken:
+		return "api.auth_token changed"
+	case oldCfg.API.AuthTokenFile != newCfg.API.AuthTokenFile:
+		return "api.auth_token_file changed"
+	case oldCfg.API.TLSCertFile != newCfg.API.TLSCertFile:
+		return "api.tls_cert_file changed"
+	case oldCfg.API.TLSKeyFile != newCfg.API.TLSKeyFile:
+		return "api.tls_key_file changed"
 	default:
 		return ""
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -75,6 +76,11 @@ func generateSelfSignedCert(t *testing.T) (certPath, keyPath string) {
 // the full lifecycle without going through signal delivery.
 func shutdown(srv *Server) {
 	srv.cancel()
+	if srv.apiServer != nil {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = srv.apiServer.Shutdown(shutCtx)
+		cancel()
+	}
 	for _, l := range srv.listeners {
 		_ = l.Close()
 	}
@@ -189,6 +195,82 @@ func TestStart_TLSBadCertPath(t *testing.T) {
 	}
 	if got := err.Error(); !contains(got, "TLS key pair") {
 		t.Errorf("Start error: got %q, want contains 'TLS key pair'", got)
+	}
+}
+
+// TestStart_APIBindFailure asserts that a port-already-in-use on the API
+// listener is reported synchronously from Start, not silently swallowed by
+// the background Serve goroutine.
+func TestStart_APIBindFailure(t *testing.T) {
+	t.Parallel()
+	// Pre-bind a port and keep it bound so the API server's Listen fails.
+	pre, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("pre-bind: %v", err)
+	}
+	defer pre.Close()
+
+	srv := newTestServer(t, &config.Config{
+		Server: config.ServerConfig{
+			Mode:          "local",
+			ListenAddress: "127.0.0.1:0",
+		},
+		LocalStorage: config.LocalStorageConfig{
+			LogDirectory:    t.TempDir(),
+			DirPermissions:  0750,
+			FilePermissions: 0640,
+		},
+		API: config.APIConfig{
+			ListenAddress: pre.Addr().String(),
+			AuthToken:     "secret",
+		},
+	})
+	defer shutdown(srv)
+
+	err = srv.Start()
+	if err == nil {
+		t.Fatal("Start: want error, got nil")
+	}
+	if got := err.Error(); !contains(got, "management API") {
+		t.Errorf("Start error: got %q, want contains 'management API'", got)
+	}
+	if srv.apiServer != nil {
+		t.Errorf("apiServer should not be set after a failed bind; got %#v", srv.apiServer)
+	}
+	if len(srv.listeners) != 0 {
+		t.Errorf("protocol listeners should be closed after API bind failure; got %d", len(srv.listeners))
+	}
+}
+
+// TestStart_APITLSFailure asserts that an invalid API TLS keypair is reported
+// synchronously from Start.
+func TestStart_APITLSFailure(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, &config.Config{
+		Server: config.ServerConfig{
+			Mode:          "local",
+			ListenAddress: "127.0.0.1:0",
+		},
+		LocalStorage: config.LocalStorageConfig{
+			LogDirectory:    t.TempDir(),
+			DirPermissions:  0750,
+			FilePermissions: 0640,
+		},
+		API: config.APIConfig{
+			ListenAddress: "127.0.0.1:0",
+			AuthToken:     "secret",
+			TLSCertFile:   "/nonexistent/api.crt",
+			TLSKeyFile:    "/nonexistent/api.key",
+		},
+	})
+	defer shutdown(srv)
+
+	err := srv.Start()
+	if err == nil {
+		t.Fatal("Start: want error, got nil")
+	}
+	if got := err.Error(); !contains(got, "management API") {
+		t.Errorf("Start error: got %q, want contains 'management API'", got)
 	}
 }
 

--- a/internal/sessions/registry.go
+++ b/internal/sessions/registry.go
@@ -1,0 +1,136 @@
+// Package sessions provides an in-memory registry of currently active sudo
+// sessions for the management API. The registry is keyed by the server-side
+// session UUID (matching the value already emitted as log_id in slog) and is
+// populated by the connection handler when an AcceptMessage or RestartMessage
+// initializes a session, then drained when the connection terminates.
+package sessions
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SessionInfo is the registry record for one active session. Static fields are
+// populated at registration time; live fields are obtained via Provider on
+// demand so the API never returns stale counters.
+type SessionInfo struct {
+	SessionID    string           // sessionUUID.String(); registry key
+	ServerLogID  string           // base64-encoded sudo log_id; populated after session init
+	SessionUUID  uuid.UUID        // raw UUID
+	Mode         string           // "local" or "relay"
+	RemoteAddr   string           // client connection's remote address
+	StartedAt    time.Time        // server-side connection start
+	SubmitTime   time.Time        // AcceptMessage.submit_time
+	ExpectIobufs bool             // whether I/O buffers are expected for this session
+	Info         map[string]any   // flattened AcceptMessage.InfoMsgs
+	Provider     MetadataProvider // optional accessor for live counters
+}
+
+// MetadataProvider is implemented by session types that can expose live
+// counters to the management API. Sessions that do not implement it appear in
+// the registry with zero-valued LiveStats.
+type MetadataProvider interface {
+	LiveStats() LiveStats
+}
+
+// LiveStats is a snapshot of mutable per-session state. Mode-specific fields
+// (SessionDir, CacheFile, Phase) are populated only when relevant.
+type LiveStats struct {
+	MessagesReceived int64
+	BytesReceived    int64
+	LastActivity     time.Time
+	SessionDir       string // local mode: on-disk session directory
+	CacheFile        string // relay mode: cache file path
+	Phase            string // relay mode: "writing" or "flushing"
+}
+
+// Registry holds the active session set. The zero value is not usable; call
+// NewRegistry. It is safe for concurrent use.
+//
+// Records are stored by value and returned by value, so callers reading from
+// the API path never observe in-flight mutations from a registering goroutine.
+// The static fields of SessionInfo are set once at Register time; live
+// counters are read through the MetadataProvider hook, which uses its own
+// synchronization (typically sync/atomic) on the underlying session.
+type Registry struct {
+	mu       sync.RWMutex
+	sessions map[string]SessionInfo
+}
+
+// NewRegistry returns an empty registry ready for use.
+func NewRegistry() *Registry {
+	return &Registry{sessions: make(map[string]SessionInfo)}
+}
+
+// Register adds a session to the registry, replacing any existing entry with
+// the same SessionID. A nil receiver is a no-op so callers that may not have a
+// registry (e.g., unit tests) can call this unconditionally.
+func (r *Registry) Register(info SessionInfo) {
+	if r == nil || info.SessionID == "" {
+		return
+	}
+	r.mu.Lock()
+	r.sessions[info.SessionID] = info
+	r.mu.Unlock()
+}
+
+// Deregister removes the session with the given ID. Missing IDs are silently
+// ignored. A nil receiver is a no-op.
+func (r *Registry) Deregister(sessionID string) {
+	if r == nil || sessionID == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.sessions, sessionID)
+	r.mu.Unlock()
+}
+
+// Get returns a copy of the registered session matching id. The lookup tries
+// the SessionID (UUID form) first, then falls back to a linear scan for a
+// matching ServerLogID so callers can paste either form.
+func (r *Registry) Get(id string) (SessionInfo, bool) {
+	if r == nil || id == "" {
+		return SessionInfo{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if s, ok := r.sessions[id]; ok {
+		return s, true
+	}
+	for _, s := range r.sessions {
+		if s.ServerLogID != "" && s.ServerLogID == id {
+			return s, true
+		}
+	}
+	return SessionInfo{}, false
+}
+
+// Snapshot returns copies of the active sessions, sorted by StartedAt
+// descending (newest first). The returned slice is decoupled from the
+// underlying map; callers may iterate without holding the registry lock.
+func (r *Registry) Snapshot() []SessionInfo {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	out := make([]SessionInfo, 0, len(r.sessions))
+	for _, s := range r.sessions {
+		out = append(out, s)
+	}
+	r.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].StartedAt.After(out[j].StartedAt) })
+	return out
+}
+
+// Len returns the current number of registered sessions.
+func (r *Registry) Len() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.sessions)
+}

--- a/internal/sessions/registry_test.go
+++ b/internal/sessions/registry_test.go
@@ -1,0 +1,233 @@
+package sessions
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type fakeProvider struct {
+	stats LiveStats
+}
+
+func (f *fakeProvider) LiveStats() LiveStats { return f.stats }
+
+func newInfo(t *testing.T, mode string) SessionInfo {
+	t.Helper()
+	id := uuid.New()
+	return SessionInfo{
+		SessionID:   id.String(),
+		SessionUUID: id,
+		Mode:        mode,
+		StartedAt:   time.Now(),
+	}
+}
+
+func TestRegistry_RegisterGetDeregister(t *testing.T) {
+	r := NewRegistry()
+	info := newInfo(t, "local")
+	info.ServerLogID = "log-id-base64"
+
+	r.Register(info)
+	if got := r.Len(); got != 1 {
+		t.Fatalf("Len after register = %d, want 1", got)
+	}
+
+	got, ok := r.Get(info.SessionID)
+	if !ok || got.SessionID != info.SessionID {
+		t.Fatalf("Get by SessionID returned (%+v, %v); want session %q", got, ok, info.SessionID)
+	}
+
+	got, ok = r.Get("log-id-base64")
+	if !ok || got.SessionID != info.SessionID {
+		t.Fatalf("Get by ServerLogID returned (%+v, %v); want session %q", got, ok, info.SessionID)
+	}
+
+	if _, ok := r.Get("does-not-exist"); ok {
+		t.Fatalf("Get returned ok for unknown id")
+	}
+
+	r.Deregister(info.SessionID)
+	if got := r.Len(); got != 0 {
+		t.Fatalf("Len after deregister = %d, want 0", got)
+	}
+	if _, ok := r.Get(info.SessionID); ok {
+		t.Fatalf("Get after deregister returned ok")
+	}
+}
+
+// TestRegistry_GetReturnsCopy asserts that mutating the returned SessionInfo
+// does not affect the registry's stored record. This is the structural fix
+// for the data race called out in the adversarial review: callers cannot
+// observe (or cause) in-flight mutations to records held by the registry.
+func TestRegistry_GetReturnsCopy(t *testing.T) {
+	r := NewRegistry()
+	info := newInfo(t, "local")
+	info.ServerLogID = "original"
+	r.Register(info)
+
+	got, _ := r.Get(info.SessionID)
+	got.ServerLogID = "mutated-by-caller"
+
+	again, _ := r.Get(info.SessionID)
+	if again.ServerLogID != "original" {
+		t.Fatalf("registry record mutated by caller: ServerLogID = %q, want %q",
+			again.ServerLogID, "original")
+	}
+}
+
+func TestRegistry_Snapshot_OrderAndIsolation(t *testing.T) {
+	r := NewRegistry()
+	now := time.Now()
+
+	older := newInfo(t, "local")
+	older.StartedAt = now.Add(-time.Minute)
+	newer := newInfo(t, "local")
+	newer.StartedAt = now
+
+	r.Register(older)
+	r.Register(newer)
+
+	snap := r.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("Snapshot len = %d, want 2", len(snap))
+	}
+	if snap[0].SessionID != newer.SessionID {
+		t.Fatalf("Snapshot[0] = %v; want newest first", snap[0].SessionID)
+	}
+
+	// Mutating the registry after Snapshot must not change the returned slice length.
+	r.Deregister(older.SessionID)
+	if len(snap) != 2 {
+		t.Fatalf("Snapshot mutated by post-snapshot Deregister; len = %d, want 2", len(snap))
+	}
+}
+
+func TestRegistry_NilSafety(t *testing.T) {
+	var r *Registry
+	r.Register(SessionInfo{SessionID: "x"})
+	r.Deregister("x")
+	if got := r.Len(); got != 0 {
+		t.Fatalf("nil registry Len = %d, want 0", got)
+	}
+	if _, ok := r.Get("x"); ok {
+		t.Fatalf("nil registry Get returned ok")
+	}
+	if snap := r.Snapshot(); snap != nil {
+		t.Fatalf("nil registry Snapshot = %v, want nil", snap)
+	}
+}
+
+func TestRegistry_RejectsEmptyOrNil(t *testing.T) {
+	r := NewRegistry()
+	r.Register(SessionInfo{}) // empty SessionID
+	if r.Len() != 0 {
+		t.Fatalf("Register accepted invalid input; Len = %d", r.Len())
+	}
+}
+
+func TestRegistry_LiveStatsViaProvider(t *testing.T) {
+	r := NewRegistry()
+	info := newInfo(t, "local")
+	info.Provider = &fakeProvider{stats: LiveStats{MessagesReceived: 7, BytesReceived: 1024}}
+	r.Register(info)
+
+	got, ok := r.Get(info.SessionID)
+	if !ok {
+		t.Fatal("Get failed")
+	}
+	stats := got.Provider.LiveStats()
+	if stats.MessagesReceived != 7 || stats.BytesReceived != 1024 {
+		t.Fatalf("LiveStats = %+v; want MessagesReceived=7 BytesReceived=1024", stats)
+	}
+}
+
+// TestRegistry_Concurrent_RegisterDeregisterSnapshot exercises the locking
+// model under -race. It alternates registers and deregisters from many
+// goroutines while another set of goroutines reads via Get and Snapshot.
+func TestRegistry_Concurrent_RegisterDeregisterSnapshot(t *testing.T) {
+	r := NewRegistry()
+	const writers = 16
+	const readers = 8
+	const opsPerWriter = 200
+
+	ids := make([]string, writers*opsPerWriter)
+	for i := range ids {
+		ids[i] = uuid.New().String()
+	}
+
+	// Writers and readers use separate WaitGroups so we can deterministically
+	// wait for writer completion (a known finite work set) without busy-polling
+	// a counter. The reader pool runs until we explicitly stop it.
+	var writersWG, readersWG sync.WaitGroup
+	stop := make(chan struct{})
+
+	for w := range writers {
+		writersWG.Go(func() {
+			start := w * opsPerWriter
+			for i := range opsPerWriter {
+				id := ids[start+i]
+				r.Register(SessionInfo{
+					SessionID:   id,
+					SessionUUID: uuid.MustParse(id),
+					Mode:        "local",
+					StartedAt:   time.Now(),
+				})
+				r.Deregister(id)
+			}
+		})
+	}
+
+	for range readers {
+		readersWG.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = r.Snapshot()
+				_, _ = r.Get(ids[0])
+			}
+		})
+	}
+
+	writersWG.Wait()
+	close(stop)
+	readersWG.Wait()
+
+	if got := r.Len(); got != 0 {
+		t.Fatalf("Registry not empty after balanced register/deregister; len=%d", got)
+	}
+}
+
+func BenchmarkRegistry_Snapshot(b *testing.B) {
+	r := NewRegistry()
+	for range 1000 {
+		id := uuid.New()
+		r.Register(SessionInfo{SessionID: id.String(), SessionUUID: id, StartedAt: time.Now()})
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		_ = r.Snapshot()
+	}
+}
+
+// Sanity: ensure %v formatting of a SessionInfo doesn't panic, useful when
+// tests include diagnostic output.
+func TestSessionInfo_FormatStable(t *testing.T) {
+	id := uuid.New()
+	info := &SessionInfo{
+		SessionID:   id.String(),
+		SessionUUID: id,
+		Mode:        "local",
+		StartedAt:   time.Unix(0, 0),
+		Info:        map[string]any{"submituser": "alice"},
+	}
+	if s := fmt.Sprintf("%+v", info); s == "" {
+		t.Fatal("empty format output")
+	}
+}

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -15,12 +15,15 @@ import (
 	"path/filepath"
 	"strings"
 	"sudosrv/internal/config"
+	"sudosrv/internal/sessions"
 	pb "sudosrv/pkg/sudosrv_proto"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
 )
 
 // commitPointInterval matches C sudo_logsrvd's ACK_FREQUENCY (10 seconds).
@@ -44,6 +47,12 @@ type Session struct {
 	fileMux         sync.Mutex
 	closeOnce       sync.Once
 	isInitialized   bool
+	// Live stats exposed to the management API. Updated with atomic ops so
+	// the API's read path never blocks on fileMux held by the write path.
+	// Writes themselves still happen while fileMux is held by HandleClientMessage.
+	msgCount      atomic.Int64
+	bytesReceived atomic.Int64
+	lastActivity  atomic.Pointer[time.Time]
 }
 
 // IO event types for the timing file, matching native sudo implementation.
@@ -220,6 +229,10 @@ type EventSession struct {
 	logJSONPath string
 	logMeta     map[string]any
 	closeOnce   sync.Once
+	// Live stats exposed to the management API.
+	msgCount      atomic.Int64
+	bytesReceived atomic.Int64
+	lastActivity  atomic.Pointer[time.Time]
 }
 
 // NewEventSession creates a local metadata-only session for an accepted command
@@ -265,7 +278,28 @@ func NewEventSession(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *co
 	return event, nil
 }
 
+// LogID returns the base64-encoded sudo log_id assigned when the event session
+// was created. It is stable for the lifetime of the session.
+func (s *EventSession) LogID() string { return s.logID }
+
+// LiveStats returns a snapshot of mutable counters for the management API.
+func (s *EventSession) LiveStats() sessions.LiveStats {
+	stats := sessions.LiveStats{
+		MessagesReceived: s.msgCount.Load(),
+		BytesReceived:    s.bytesReceived.Load(),
+		SessionDir:       s.sessionDir,
+	}
+	if t := s.lastActivity.Load(); t != nil {
+		stats.LastActivity = *t
+	}
+	return stats
+}
+
 func (s *EventSession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
+	s.msgCount.Add(1)
+	s.bytesReceived.Add(int64(proto.Size(msg)))
+	now := time.Now()
+	s.lastActivity.Store(&now)
 	switch event := msg.Type.(type) {
 	case *pb.ClientMessage_ExitMsg:
 		s.finalize(event.ExitMsg)
@@ -595,8 +629,37 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 	return seqStr, nil
 }
 
+// LogID returns the base64-encoded sudo log_id assigned when the session was
+// created. It is stable for the lifetime of the session.
+func (s *Session) LogID() string { return s.logID }
+
+// LiveStats returns a snapshot of mutable counters for the management API.
+// Counters are read with atomic loads; this method does not contend with the
+// file-write fileMux.
+func (s *Session) LiveStats() sessions.LiveStats {
+	stats := sessions.LiveStats{
+		MessagesReceived: s.msgCount.Load(),
+		BytesReceived:    s.bytesReceived.Load(),
+		SessionDir:       s.sessionDir,
+	}
+	if t := s.lastActivity.Load(); t != nil {
+		stats.LastActivity = *t
+	}
+	return stats
+}
+
+// recordActivity updates the live counters used by the management API. Called
+// from HandleClientMessage on every message.
+func (s *Session) recordActivity(msg *pb.ClientMessage) {
+	s.msgCount.Add(1)
+	s.bytesReceived.Add(int64(proto.Size(msg)))
+	now := time.Now()
+	s.lastActivity.Store(&now)
+}
+
 // HandleClientMessage processes a message from the client.
 func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
+	s.recordActivity(msg)
 	s.fileMux.Lock()
 	defer s.fileMux.Unlock()
 


### PR DESCRIPTION
Adds a small read-only HTTP+JSON API that exposes currently active sessions and their metadata. Enables operators to answer "what is sudo running right now?" without scraping logs.

Endpoints (bearer-token auth, optional TLS):
  GET /api/v1/sessions             list active sessions, newest first
  GET /api/v1/sessions/{id}        full metadata for one session

The API is disabled by default; an empty api.listen_address skips it entirely. AuthTokenFile is preferred over inline AuthToken so the secret stays out of YAML.

New packages:
  internal/sessions/  Registry keyed by sessionUUID.String() with a
                      MetadataProvider hook for live counters. Records
                      are stored and returned by value, so API readers
                      never observe in-flight mutations.
  internal/api/       net/http server with Listen()+Serve() split,
                      constant-time bearer-token middleware via
                      crypto/subtle, JSON helpers.

Session types (storage.Session, storage.EventSession, relay.Session) implement LogID() and LiveStats() with sync/atomic counters so the API path never contends with the file-write fileMux. The relay session
also tracks a writing -> flushing phase transition and exposes IsDone() for race-free deregistration handoff.

connection.Handler threads the registry through NewHandlerWithContext, registers in handleAccept/handleEventOnlyAccept/handleRestart, and deregisters in its existing Handle() defer. Sessions whose lifetime outlives the connection (relay) are marked by a doneNotifier interface and own their own deregistration via an onDone callback fired when their background runner exits. registerSession also handles the done-before-register race by deregistering immediately if the runner has already finished.

server.Server constructs the registry and starts the API alongside protocol listeners. Start() is transactional: every listener (plain, TLS, API) binds synchronously before any accept or serve goroutine spawns, so a late bind failure cannot leak partial protocol state. The API shuts down first in Wait() so callers see a clean refusal during teardown rather than a stale snapshot. restartRequiredReloadChange flags API config changes since token rotation requires restart.

Tests cover registry concurrency under -race, return-by-value isolation, the HTTP handlers via httptest, full TCP-protocol round-trip e2e (AcceptMessage to API visibility to deregister-on-disconnect), relay flush visibility (unreachable upstream keeps phase=flushing visible after disconnect), atomic startup failure paths (port-in-use
and bad TLS), the disabled-by-default case, and the done-before-register orphan race.

Docs: config-example.yaml, README "Management API" section.
