### PR TITLE
Bound graceful shutdown and apply code-review follow-ups

### DIFF
--- a/cmd/sudosrv/main.go
+++ b/cmd/sudosrv/main.go
@@ -242,8 +242,10 @@ func runServerWithGracefulShutdown(cfg *config.Config, configPath string, logLev
 
 	slog.Info("Server started successfully")
 
-	// Wait for shutdown signal and handle graceful shutdown
-	srv.Wait()
+	// Wait for shutdown signal and handle graceful shutdown.
+	// shutdownTimeout bounds how long we wait for goroutines after SIGTERM/SIGINT
+	// before logging and returning so the process can actually exit.
+	srv.Wait(shutdownTimeout)
 
 	slog.Info("Server shutdown completed")
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 // Filename: go.mod
 module sudosrv
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0
-	google.golang.org/protobuf v1.36.6
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -15,10 +15,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
-google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -177,11 +177,13 @@ func (h *Handler) Handle() {
 			}
 		}
 
-		// Apply rate limiting to prevent memory exhaustion
+		// Apply rate limiting to prevent memory exhaustion.
+		// All writes below use h.ctx so a stalled client can't pin the handler
+		// past shutdown — see Server.Wait's bounded grace period.
 		if !h.checkRateLimit() {
 			slog.Warn("Rate limit exceeded, closing connection", "remote_addr", h.conn.RemoteAddr())
 			errMsg := &pb.ServerMessage{Type: &pb.ServerMessage_Error{Error: "Rate limit exceeded"}}
-			_ = h.processor.WriteServerMessage(errMsg)
+			_ = h.processor.WriteServerMessageContext(h.ctx, errMsg)
 			return
 		}
 
@@ -192,14 +194,14 @@ func (h *Handler) Handle() {
 				"message_errors", metrics.Global.GetMessageErrors())
 			// Attempt to send a fatal error to the client
 			errMsg := &pb.ServerMessage{Type: &pb.ServerMessage_Error{Error: "Internal Server Error"}}
-			_ = h.processor.WriteServerMessage(errMsg)
+			_ = h.processor.WriteServerMessageContext(h.ctx, errMsg)
 			return
 		}
 
 		metrics.Global.IncrementMessagesProcessed()
 
 		if serverMsg != nil {
-			if err := h.processor.WriteServerMessage(serverMsg); err != nil {
+			if err := h.processor.WriteServerMessageContext(h.ctx, serverMsg); err != nil {
 				slog.Error("Failed to write server message", "error", err, "remote_addr", h.conn.RemoteAddr())
 				return
 			}
@@ -346,6 +348,18 @@ func (h *Handler) registerRestartSession(restartMsg *pb.RestartMessage) {
 		info.Provider = p
 	}
 	h.registry.Register(info)
+}
+
+// refreshLogIDFromSession overwrites h.logID with the session's authoritative
+// base64-encoded server log_id. Until the session is created, h.logID holds the
+// raw UUID string for early diagnostic logging. Once the session exists, the
+// log_id used by storage on disk, by the management API, and returned to the
+// client is the base64 form — slog must use the same form so operators can
+// correlate log entries with sessions.
+func (h *Handler) refreshLogIDFromSession() {
+	if lp, ok := h.session.(logIDProvider); ok {
+		h.logID = lp.LogID()
+	}
 }
 
 // handleHello responds to a ClientHello.
@@ -573,6 +587,7 @@ func (h *Handler) handleAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create local storage session: %w", err)
 		}
+		h.refreshLogIDFromSession()
 		h.registerSession(sessionUUID, "local", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementLocalSessions()
@@ -584,6 +599,7 @@ func (h *Handler) handleAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create relay session: %w", err)
 		}
+		h.refreshLogIDFromSession()
 		h.registerSession(sessionUUID, "relay", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementRelaySessions()
@@ -611,6 +627,7 @@ func (h *Handler) handleEventOnlyAccept(sessionUUID uuid.UUID, acceptMsg *pb.Acc
 			return nil, fmt.Errorf("failed to create local event-only session: %w", err)
 		}
 		h.session = session
+		h.refreshLogIDFromSession()
 		h.registerSession(sessionUUID, "local", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementLocalSessions()
@@ -622,6 +639,7 @@ func (h *Handler) handleEventOnlyAccept(sessionUUID uuid.UUID, acceptMsg *pb.Acc
 			return nil, fmt.Errorf("failed to create relay event-only session: %w", err)
 		}
 		h.session = session
+		h.refreshLogIDFromSession()
 		h.registerSession(sessionUUID, "relay", acceptMsg)
 		metrics.Global.IncrementSessions()
 		metrics.Global.IncrementRelaySessions()

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -482,7 +482,7 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 	}
 
 	// Build the event record
-	eventRecord := map[string]interface{}{
+	eventRecord := map[string]any{
 		"event_type": "reject",
 		"reason":     rejectMsg.GetReason(),
 	}
@@ -491,7 +491,7 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 	}
 
 	// Extract info messages
-	infoMap := make(map[string]interface{})
+	infoMap := make(map[string]any)
 	for _, info := range rejectMsg.GetInfoMsgs() {
 		key := info.GetKey()
 		switch v := info.Value.(type) {

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -42,6 +42,7 @@ type Handler struct {
 	// sessionFactories allows for injecting mock session creators during tests.
 	sessionFactories struct {
 		newLocalStorageSession func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
+		newLocalEventSession   func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
 		newRelaySession        func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig) (SessionHandler, error)
 		newLocalRestartSession func(restartMsg *pb.RestartMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
 	}
@@ -106,6 +107,9 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 	// Initialize factories to point to the real session creation functions.
 	h.sessionFactories.newLocalStorageSession = func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, localCfg *config.LocalStorageConfig) (SessionHandler, error) {
 		return storage.NewSession(sessionUUID, acceptMsg, localCfg)
+	}
+	h.sessionFactories.newLocalEventSession = func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, localCfg *config.LocalStorageConfig) (SessionHandler, error) {
+		return storage.NewEventSession(sessionUUID, acceptMsg, localCfg)
 	}
 	h.sessionFactories.newRelaySession = func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, relayCfg *config.RelayConfig) (SessionHandler, error) {
 		// onDone is invoked from the relay's background runner goroutine
@@ -584,13 +588,13 @@ func (h *Handler) handleAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, 
 func (h *Handler) handleEventOnlyAccept(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, error) {
 	slog.Info("Handling event-only log (no I/O buffers expected)", "remote_addr", h.conn.RemoteAddr())
 
+	var err error
 	switch h.config.Server.Mode {
 	case "local":
-		session, err := storage.NewEventSession(sessionUUID, acceptMsg, &h.config.LocalStorage)
+		h.session, err = h.sessionFactories.newLocalEventSession(sessionUUID, acceptMsg, &h.config.LocalStorage)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create local event-only session: %w", err)
 		}
-		h.session = session
 		h.refreshLogIDFromSession()
 		h.registerSession(sessionUUID, "local", acceptMsg)
 		metrics.Global.IncrementSessions()
@@ -598,11 +602,10 @@ func (h *Handler) handleEventOnlyAccept(sessionUUID uuid.UUID, acceptMsg *pb.Acc
 		slog.Info("Started local event-only session", "log_id", h.logID,
 			"total_sessions", metrics.Global.GetTotalSessions(), "local_sessions", metrics.Global.GetLocalSessions())
 	case "relay":
-		session, err := h.sessionFactories.newRelaySession(sessionUUID, acceptMsg, &h.config.Relay)
+		h.session, err = h.sessionFactories.newRelaySession(sessionUUID, acceptMsg, &h.config.Relay)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create relay event-only session: %w", err)
 		}
-		h.session = session
 		h.refreshLogIDFromSession()
 		h.registerSession(sessionUUID, "relay", acceptMsg)
 		metrics.Global.IncrementSessions()

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -117,9 +117,15 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 		// here at construction time. The connection-side defer skips
 		// deregistering relay sessions for this reason; deregister via
 		// onDone so "phase: flushing" stays visible in the management API
-		// until the flush truly completes.
+		// until the flush truly completes. The active-sessions metric is
+		// decremented here for the same reason: until the flush finishes
+		// the session is still consuming server resources (cache file +
+		// flush goroutine), so it should count as active.
 		sid := sessionUUID.String()
-		onDone := func() { h.registry.Deregister(sid) }
+		onDone := func() {
+			h.registry.Deregister(sid)
+			metrics.Global.DecrementActiveSessions()
+		}
 		return relay.NewSession(h.ctx, sessionUUID, acceptMsg, relayCfg, onDone)
 	}
 	h.sessionFactories.newLocalRestartSession = func(restartMsg *pb.RestartMessage, localCfg *config.LocalStorageConfig) (SessionHandler, error) {
@@ -132,16 +138,20 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 func (h *Handler) Handle() {
 	defer func() {
 		if h.session != nil {
-			// Local sessions are fully closed by Close(); deregister now.
-			// Self-deregistering sessions (relay) own the registry entry's
-			// lifetime via their onDone callback, which fires when their
-			// background flusher exits — possibly long after the connection
-			// closes. Hiding the "phase: flushing" record on disconnect
-			// would defeat the management API's purpose.
-			if _, selfDeregistering := h.session.(doneNotifier); !selfDeregistering && h.registry != nil {
-				h.registry.Deregister(h.sessionID)
+			// Local sessions are fully closed by Close(); deregister and
+			// decrement the active count now. Self-deregistering sessions
+			// (relay) own the registry entry's lifetime — and the
+			// active-sessions metric — via their onDone callback, which
+			// fires when their background flusher exits, possibly long
+			// after the connection closes. Hiding "phase: flushing"
+			// records or decrementing the metric on disconnect would
+			// defeat the management API's purpose.
+			if _, selfDeregistering := h.session.(doneNotifier); !selfDeregistering {
+				if h.registry != nil {
+					h.registry.Deregister(h.sessionID)
+				}
+				metrics.Global.DecrementActiveSessions()
 			}
-			metrics.Global.DecrementActiveSessions()
 			if err := h.session.Close(); err != nil {
 				slog.Error("Failed to close session", "error", err, "remote_addr", h.conn.RemoteAddr())
 			}

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -262,29 +262,6 @@ func (h *Handler) processMessage(clientMsg *pb.ClientMessage) (*pb.ServerMessage
 	}
 }
 
-// flattenInfoMsgs converts repeated InfoMessage entries into a JSON-friendly
-// map[string]any keyed by InfoMessage.key. Mirrors the per-type switch used
-// when persisting log.json so the management API and the on-disk record carry
-// the same shape.
-func flattenInfoMsgs(infos []*pb.InfoMessage) map[string]any {
-	out := make(map[string]any, len(infos))
-	for _, info := range infos {
-		key := info.GetKey()
-		if key == "" {
-			continue
-		}
-		switch v := info.Value.(type) {
-		case *pb.InfoMessage_Strval:
-			out[key] = v.Strval
-		case *pb.InfoMessage_Numval:
-			out[key] = v.Numval
-		case *pb.InfoMessage_Strlistval:
-			out[key] = v.Strlistval.GetStrings()
-		}
-	}
-	return out
-}
-
 // registerSession adds the just-created session to the registry, if one is
 // configured. Static fields are populated from the AcceptMessage; the live
 // MetadataProvider hook is set when the session implements it. ServerLogID is
@@ -303,7 +280,7 @@ func (h *Handler) registerSession(sessionUUID uuid.UUID, mode string, acceptMsg 
 		RemoteAddr:   h.conn.RemoteAddr().String(),
 		StartedAt:    h.startedAt,
 		ExpectIobufs: acceptMsg.GetExpectIobufs(),
-		Info:         flattenInfoMsgs(acceptMsg.GetInfoMsgs()),
+		Info:         protocol.InfoMsgsToMap(acceptMsg.GetInfoMsgs()),
 	}
 	if st := acceptMsg.GetSubmitTime(); st != nil {
 		info.SubmitTime = time.Unix(st.TvSec, int64(st.TvNsec)).UTC()
@@ -490,27 +467,14 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 		eventRecord["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 	}
 
-	// Extract info messages
-	infoMap := make(map[string]any)
-	for _, info := range rejectMsg.GetInfoMsgs() {
-		key := info.GetKey()
-		switch v := info.Value.(type) {
-		case *pb.InfoMessage_Strval:
-			infoMap[key] = v.Strval
-		case *pb.InfoMessage_Numval:
-			infoMap[key] = v.Numval
-		case *pb.InfoMessage_Strlistval:
-			infoMap[key] = v.Strlistval.GetStrings()
+	// Merge client-supplied info messages into the record, but never let them
+	// overwrite the authoritative fields (event_type, reason, submit_time) we
+	// already set above.
+	for k, v := range protocol.InfoMsgsToMap(rejectMsg.GetInfoMsgs()) {
+		if _, exists := eventRecord[k]; exists {
+			continue
 		}
-	}
-	if len(infoMap) > 0 {
-		for k, v := range infoMap {
-			// Preserve authoritative fields already set by the server.
-			if _, exists := eventRecord[k]; exists {
-				continue
-			}
-			eventRecord[k] = v
-		}
+		eventRecord[k] = v
 	}
 
 	data, err := json.MarshalIndent(eventRecord, "", "  ")

--- a/internal/connection/handler_test.go
+++ b/internal/connection/handler_test.go
@@ -2,7 +2,6 @@
 package connection
 
 import (
-	"context"
 	"encoding/json"
 	"net"
 	"os"
@@ -1096,7 +1095,7 @@ func TestRelay_DoneBeforeRegisterDoesNotOrphan(t *testing.T) {
 	}
 
 	registry := sessions.NewRegistry()
-	handler := NewHandlerWithContext(context.Background(), serverConn, cfg, registry)
+	handler := NewHandlerWithContext(t.Context(), serverConn, cfg, registry)
 	handler.sessionFactories.newRelaySession = func(sessionUUID uuid.UUID, _ *pb.AcceptMessage, _ *config.RelayConfig) (SessionHandler, error) {
 		// Simulate the race: the runner finished and called Deregister
 		// before registerSession had a chance to add the entry. The

--- a/internal/protocol/infomsg.go
+++ b/internal/protocol/infomsg.go
@@ -1,0 +1,30 @@
+// Filename: internal/protocol/infomsg.go
+package protocol
+
+import pb "sudosrv/pkg/sudosrv_proto"
+
+// InfoMsgsToMap converts a slice of InfoMessage entries to a generic map keyed
+// by InfoMessage.Key. Entries with empty keys are skipped (matching C
+// sudo_logsrvd, which treats keyless entries as malformed). Strval, Numval, and
+// Strlistval values are unwrapped to their underlying Go types (string, int64,
+// []string). Unknown value variants are silently dropped — this keeps the
+// helper forward-compatible if the proto schema grows new InfoMessage value
+// types in a future sudo release.
+func InfoMsgsToMap(infos []*pb.InfoMessage) map[string]any {
+	out := make(map[string]any, len(infos))
+	for _, info := range infos {
+		key := info.GetKey()
+		if key == "" {
+			continue
+		}
+		switch v := info.Value.(type) {
+		case *pb.InfoMessage_Strval:
+			out[key] = v.Strval
+		case *pb.InfoMessage_Numval:
+			out[key] = v.Numval
+		case *pb.InfoMessage_Strlistval:
+			out[key] = v.Strlistval.GetStrings()
+		}
+	}
+	return out
+}

--- a/internal/protocol/processor_test.go
+++ b/internal/protocol/processor_test.go
@@ -194,7 +194,7 @@ func TestProcessor(t *testing.T) {
 		defer serverConn.Close()
 
 		proc := NewProcessor(serverConn, serverConn)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 		defer cancel()
 
 		_, err := proc.ReadServerMessageContext(ctx)
@@ -209,7 +209,7 @@ func TestProcessor(t *testing.T) {
 		defer serverConn.Close()
 
 		proc := NewProcessor(serverConn, serverConn)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 		defer cancel()
 
 		msg := &sudosrv_proto.ClientMessage{

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -424,28 +424,42 @@ func RecoverOrphans(ctx context.Context, cfg *config.RelayConfig) error {
 	}
 	slog.Info("Found orphaned relay files", "count", len(files))
 
+	// Bounded worker pool: spawn at most maxConcurrentFlushes goroutines, not
+	// one per file. With a stale cache from a multi-day outage `files` can run
+	// into the thousands, and the old pattern allocated a goroutine stack for
+	// every entry just to block on a 5-slot semaphore.
 	const maxConcurrentFlushes = 5
-	semaphore := make(chan struct{}, maxConcurrentFlushes)
+	workers := min(maxConcurrentFlushes, len(files))
+	jobs := make(chan string, len(files))
 	errChan := make(chan error, len(files))
 
-	for _, file := range files {
-		go func(filename string) {
-			select {
-			case semaphore <- struct{}{}:
-			case <-ctx.Done():
-				errChan <- ctx.Err()
-				return
-			}
-			defer func() { <-semaphore }()
-
-			slog.Debug("Flushing orphaned relay file", "file", filename)
-			errChan <- FlushOrphanedFile(ctx, filename, cfg)
-		}(file)
+	for _, f := range files {
+		jobs <- f
 	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for filename := range jobs {
+				// Bail between jobs on cancellation. FlushOrphanedFile is
+				// itself ctx-aware so a mid-flush cancel propagates through
+				// errChan via the returned error.
+				if err := ctx.Err(); err != nil {
+					errChan <- err
+					return
+				}
+				slog.Debug("Flushing orphaned relay file", "file", filename)
+				errChan <- FlushOrphanedFile(ctx, filename, cfg)
+			}
+		})
+	}
+	wg.Wait()
+	close(errChan)
 
 	var flushErrors []error
-	for i := 0; i < len(files); i++ {
-		if err := <-errChan; err != nil {
+	for err := range errChan {
+		if err != nil {
 			flushErrors = append(flushErrors, err)
 		}
 	}

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -187,7 +187,7 @@ func TestRelaySession_CacheAndFlush(t *testing.T) {
 	acceptMsg := createTestAcceptMessage()
 
 	// 3. Create a new relay session
-	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg, nil)
+	session, err := NewSession(t.Context(), sessionUUID, acceptMsg, relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestRelayCommitPoints(t *testing.T) {
 	sessionUUID := uuid.MustParse("b2c3d4e5-f6a7-4b2c-9d3e-0f1a2b3c4d5e")
 	acceptMsg := createTestAcceptMessage()
 
-	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg, nil)
+	session, err := NewSession(t.Context(), sessionUUID, acceptMsg, relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestRelayCommitPointThrottling(t *testing.T) {
 	sessionUUID := uuid.MustParse("c3d4e5f6-a7b8-4c3d-ae4f-1a2b3c4d5e6f")
 	acceptMsg := createTestAcceptMessage()
 
-	session, err := NewSession(context.Background(), sessionUUID, acceptMsg, relayCfg, nil)
+	session, err := NewSession(t.Context(), sessionUUID, acceptMsg, relayCfg, nil)
 	if err != nil {
 		t.Fatalf("NewSession() failed: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -195,8 +195,13 @@ func (s *Server) acceptLoop(listener net.Listener) {
 			default:
 				metrics.Global.IncrementFailedConnections()
 				slog.Error("Failed to accept connection", "error", err, "failed_connections", metrics.Global.GetFailedConnections())
-				// Brief backoff to avoid tight error loop on transient failures
-				time.Sleep(100 * time.Millisecond)
+				// Brief backoff to avoid tight error loop on transient failures.
+				// Honour ctx so shutdown is not held up for 100ms per accept loop.
+				select {
+				case <-s.ctx.Done():
+					return
+				case <-time.After(100 * time.Millisecond):
+				}
 			}
 			continue
 		}
@@ -240,7 +245,13 @@ func (s *Server) acceptLoop(listener net.Listener) {
 
 // Wait blocks until the server is shut down.
 // SIGHUP triggers a config reload; SIGINT/SIGTERM trigger graceful shutdown.
-func (s *Server) Wait() {
+//
+// shutdownTimeout caps the time spent waiting for goroutines after shutdown is
+// signalled. A wedged handler (slow client, stuck syscall) cannot then block
+// the process from exiting; the timeout fires and we return with a warning so
+// the surrounding process supervisor can take over. Zero disables the cap and
+// blocks indefinitely.
+func (s *Server) Wait(shutdownTimeout time.Duration) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer signal.Stop(sigChan)
@@ -278,8 +289,24 @@ func (s *Server) Wait() {
 		}
 	}
 
-	// Wait for all goroutines to finish
-	s.waitGroup.Wait()
+	// Wait for all goroutines to finish, bounded by shutdownTimeout.
+	done := make(chan struct{})
+	go func() {
+		s.waitGroup.Wait()
+		close(done)
+	}()
+	if shutdownTimeout <= 0 {
+		<-done
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(shutdownTimeout):
+		slog.Warn("Shutdown timeout exceeded; some goroutines did not exit cleanly",
+			"timeout", shutdownTimeout,
+			"active_connections", metrics.Global.GetActiveConnections(),
+			"active_sessions", metrics.Global.GetActiveSessions())
+	}
 }
 
 // reload re-reads the configuration file and applies changes that can be

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,13 +134,11 @@ func (s *Server) Start() error {
 		slog.Info("Started TLS listener", "address", tlsAddr)
 	}
 	if s.apiServer != nil {
-		s.waitGroup.Add(1)
-		go func() {
-			defer s.waitGroup.Done()
+		s.waitGroup.Go(func() {
 			if err := s.apiServer.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				slog.Error("Management API server exited with error", "error", err)
 			}
-		}()
+		})
 		slog.Info("Started management API",
 			"address", s.apiServer.Addr(),
 			"tls", cfg.API.TLSCertFile != "")
@@ -152,13 +150,11 @@ func (s *Server) Start() error {
 	go s.logMetricsPeriodically()
 
 	if cfg.Server.Mode == "relay" {
-		s.waitGroup.Add(1)
-		go func() {
-			defer s.waitGroup.Done()
+		s.waitGroup.Go(func() {
 			if err := relay.RecoverOrphans(s.ctx, &cfg.Relay); err != nil {
 				slog.Error("Orphan relay recovery reported errors", "error", err)
 			}
-		}()
+		})
 	}
 
 	return nil

--- a/internal/sessions/registry.go
+++ b/internal/sessions/registry.go
@@ -6,7 +6,7 @@
 package sessions
 
 import (
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -121,7 +121,8 @@ func (r *Registry) Snapshot() []SessionInfo {
 		out = append(out, s)
 	}
 	r.mu.RUnlock()
-	sort.Slice(out, func(i, j int) bool { return out[i].StartedAt.After(out[j].StartedAt) })
+	// Newest-first by StartedAt; Compare(b, a) so larger (newer) sorts first.
+	slices.SortFunc(out, func(a, b SessionInfo) int { return b.StartedAt.Compare(a.StartedAt) })
 	return out
 }
 

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -10,12 +10,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"math/big"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sudosrv/internal/config"
+	"sudosrv/internal/protocol"
 	"sudosrv/internal/sessions"
 	pb "sudosrv/pkg/sudosrv_proto"
 	"sync"
@@ -252,7 +254,7 @@ func NewEventSession(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *co
 		logJSONPath: filepath.Join(sessionDir, "log.json"),
 		logMeta:     make(map[string]any),
 	}
-	event.addInfoMessages(acceptMsg.GetInfoMsgs())
+	maps.Copy(event.logMeta, protocol.InfoMsgsToMap(acceptMsg.GetInfoMsgs()))
 	event.logMeta["event_type"] = "accept"
 	event.logMeta["server_log_id"] = logID
 	event.logMeta["expect_iobufs"] = false
@@ -305,9 +307,7 @@ func (s *EventSession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMes
 		if alertTime := event.AlertMsg.GetAlertTime(); alertTime != nil {
 			alert["alert_time"] = time.Unix(alertTime.TvSec, int64(alertTime.TvNsec)).UTC().Format(time.RFC3339Nano)
 		}
-		info := make(map[string]any)
-		addInfoMessagesToMap(info, event.AlertMsg.GetInfoMsgs())
-		if len(info) > 0 {
+		if info := protocol.InfoMsgsToMap(event.AlertMsg.GetInfoMsgs()); len(info) > 0 {
 			alert["info"] = info
 		}
 		alerts, _ := s.logMeta["alerts"].([]any)
@@ -316,10 +316,14 @@ func (s *EventSession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMes
 		return nil, s.updateLogJSON()
 	case *pb.ClientMessage_AcceptMsg:
 		entry := map[string]any{"event_type": "accept"}
-		addInfoMessagesToMap(entry, event.AcceptMsg.GetInfoMsgs())
-		entry["event_type"] = "accept"
 		if st := event.AcceptMsg.GetSubmitTime(); st != nil {
 			entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
+		}
+		for k, v := range protocol.InfoMsgsToMap(event.AcceptMsg.GetInfoMsgs()) {
+			if _, exists := entry[k]; exists {
+				continue
+			}
+			entry[k] = v
 		}
 		subCmds, _ := s.logMeta["sub_commands"].([]any)
 		subCmds = append(subCmds, entry)
@@ -330,11 +334,14 @@ func (s *EventSession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMes
 			"event_type": "reject",
 			"reason":     event.RejectMsg.GetReason(),
 		}
-		addInfoMessagesToMap(entry, event.RejectMsg.GetInfoMsgs())
-		entry["event_type"] = "reject"
-		entry["reason"] = event.RejectMsg.GetReason()
 		if st := event.RejectMsg.GetSubmitTime(); st != nil {
 			entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
+		}
+		for k, v := range protocol.InfoMsgsToMap(event.RejectMsg.GetInfoMsgs()) {
+			if _, exists := entry[k]; exists {
+				continue
+			}
+			entry[k] = v
 		}
 		subCmds, _ := s.logMeta["sub_commands"].([]any)
 		subCmds = append(subCmds, entry)
@@ -350,27 +357,6 @@ func (s *EventSession) Close() error {
 		slog.Info("Closed local event-only session", "log_id", s.logID)
 	})
 	return nil
-}
-
-func (s *EventSession) addInfoMessages(infos []*pb.InfoMessage) {
-	addInfoMessagesToMap(s.logMeta, infos)
-}
-
-func addInfoMessagesToMap(dst map[string]any, infos []*pb.InfoMessage) {
-	for _, info := range infos {
-		key := info.GetKey()
-		if key == "" {
-			continue
-		}
-		switch v := info.Value.(type) {
-		case *pb.InfoMessage_Strval:
-			dst[key] = v.Strval
-		case *pb.InfoMessage_Numval:
-			dst[key] = v.Numval
-		case *pb.InfoMessage_Strlistval:
-			dst[key] = v.Strlistval.GetStrings()
-		}
-	}
 }
 
 func (s *EventSession) finalize(exitMsg *pb.ExitMessage) {
@@ -1010,21 +996,8 @@ func (s *Session) handleAlert(alertMsg *pb.AlertMessage) (*pb.ServerMessage, err
 		alert["alert_time"] = time.Unix(alertTime.TvSec, int64(alertTime.TvNsec)).UTC().Format(time.RFC3339Nano)
 	}
 
-	// Extract info messages
-	infoMap := make(map[string]any)
-	for _, info := range alertMsg.GetInfoMsgs() {
-		key := info.GetKey()
-		switch v := info.Value.(type) {
-		case *pb.InfoMessage_Strval:
-			infoMap[key] = v.Strval
-		case *pb.InfoMessage_Numval:
-			infoMap[key] = v.Numval
-		case *pb.InfoMessage_Strlistval:
-			infoMap[key] = v.Strlistval.GetStrings()
-		}
-	}
-	if len(infoMap) > 0 {
-		alert["info"] = infoMap
+	if info := protocol.InfoMsgsToMap(alertMsg.GetInfoMsgs()); len(info) > 0 {
+		alert["info"] = info
 	}
 
 	// Append to alerts array in metadata
@@ -1050,27 +1023,13 @@ func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.Serve
 		entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 	}
 
-	// Extract info messages
-	infoMap := make(map[string]any)
-	for _, info := range acceptMsg.GetInfoMsgs() {
-		key := info.GetKey()
-		switch v := info.Value.(type) {
-		case *pb.InfoMessage_Strval:
-			infoMap[key] = v.Strval
-		case *pb.InfoMessage_Numval:
-			infoMap[key] = v.Numval
-		case *pb.InfoMessage_Strlistval:
-			infoMap[key] = v.Strlistval.GetStrings()
+	// Merge client-supplied info messages, but never let them clobber the
+	// authoritative fields already set on entry.
+	for k, v := range protocol.InfoMsgsToMap(acceptMsg.GetInfoMsgs()) {
+		if _, exists := entry[k]; exists {
+			continue
 		}
-	}
-	if len(infoMap) > 0 {
-		for k, v := range infoMap {
-			// Preserve authoritative fields already set by the server.
-			if _, exists := entry[k]; exists {
-				continue
-			}
-			entry[k] = v
-		}
+		entry[k] = v
 	}
 
 	subCmds, _ := s.logMeta["sub_commands"].([]any)
@@ -1096,27 +1055,13 @@ func (s *Session) handleSubCommandReject(rejectMsg *pb.RejectMessage) (*pb.Serve
 		entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 	}
 
-	// Extract info messages
-	infoMap := make(map[string]any)
-	for _, info := range rejectMsg.GetInfoMsgs() {
-		key := info.GetKey()
-		switch v := info.Value.(type) {
-		case *pb.InfoMessage_Strval:
-			infoMap[key] = v.Strval
-		case *pb.InfoMessage_Numval:
-			infoMap[key] = v.Numval
-		case *pb.InfoMessage_Strlistval:
-			infoMap[key] = v.Strlistval.GetStrings()
+	// Merge client-supplied info messages, but never let them clobber the
+	// authoritative fields already set on entry.
+	for k, v := range protocol.InfoMsgsToMap(rejectMsg.GetInfoMsgs()) {
+		if _, exists := entry[k]; exists {
+			continue
 		}
-	}
-	if len(infoMap) > 0 {
-		for k, v := range infoMap {
-			// Preserve authoritative fields already set by the server.
-			if _, exists := entry[k]; exists {
-				continue
-			}
-			entry[k] = v
-		}
+		entry[k] = v
 	}
 
 	subCmds, _ := s.logMeta["sub_commands"].([]any)

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sudosrv/internal/config"
 	"sudosrv/internal/sessions"
@@ -135,12 +136,7 @@ func writeNewFile(path string, data []byte, perm os.FileMode) (err error) {
 // containsDotDot checks whether a path contains a ".." component,
 // matching C sudo_logsrvd's contains_dot_dot() check.
 func containsDotDot(path string) bool {
-	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(filepath.ToSlash(path), "/"), "..")
 }
 
 // pathWithinBase returns true when target stays lexically within base.
@@ -621,7 +617,7 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 	const base36 = "0123456789abcdefghijklmnopqrstuvwxyz"
 	seqStr := ""
 	val := nextSeq
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		seqStr = string(base36[val%36]) + seqStr
 		val /= 36
 	}

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -41,7 +41,7 @@ type Session struct {
 	timingFile      *os.File
 	logJSONPath     string // path to log.json; writes go through writeFileAtomic
 	cumulativeDelay map[string]time.Duration
-	logMeta         map[string]interface{}
+	logMeta         map[string]any
 	passwordFilter  *PasswordFilter // Password filtering for security
 	lastCommitTime  time.Time       // Tracks when last commit point was sent
 	fileMux         sync.Mutex
@@ -1007,7 +1007,7 @@ func (s *Session) handleSuspend(event *pb.CommandSuspend) (*pb.ServerMessage, er
 
 // handleAlert records a security alert in the session's log.json metadata.
 func (s *Session) handleAlert(alertMsg *pb.AlertMessage) (*pb.ServerMessage, error) {
-	alert := map[string]interface{}{
+	alert := map[string]any{
 		"reason": alertMsg.GetReason(),
 	}
 	if alertTime := alertMsg.GetAlertTime(); alertTime != nil {
@@ -1015,7 +1015,7 @@ func (s *Session) handleAlert(alertMsg *pb.AlertMessage) (*pb.ServerMessage, err
 	}
 
 	// Extract info messages
-	infoMap := make(map[string]interface{})
+	infoMap := make(map[string]any)
 	for _, info := range alertMsg.GetInfoMsgs() {
 		key := info.GetKey()
 		switch v := info.Value.(type) {
@@ -1032,7 +1032,7 @@ func (s *Session) handleAlert(alertMsg *pb.AlertMessage) (*pb.ServerMessage, err
 	}
 
 	// Append to alerts array in metadata
-	alerts, _ := s.logMeta["alerts"].([]interface{})
+	alerts, _ := s.logMeta["alerts"].([]any)
 	alerts = append(alerts, alert)
 	s.logMeta["alerts"] = alerts
 
@@ -1047,7 +1047,7 @@ func (s *Session) handleAlert(alertMsg *pb.AlertMessage) (*pb.ServerMessage, err
 // handleSubCommandAccept records a sub-command accept event in the session metadata.
 // Sub-commands share the parent session's iolog_path, matching C sudo_logsrvd behavior.
 func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.ServerMessage, error) {
-	entry := map[string]interface{}{
+	entry := map[string]any{
 		"event_type": "accept",
 	}
 	if st := acceptMsg.GetSubmitTime(); st != nil {
@@ -1055,7 +1055,7 @@ func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.Serve
 	}
 
 	// Extract info messages
-	infoMap := make(map[string]interface{})
+	infoMap := make(map[string]any)
 	for _, info := range acceptMsg.GetInfoMsgs() {
 		key := info.GetKey()
 		switch v := info.Value.(type) {
@@ -1077,7 +1077,7 @@ func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.Serve
 		}
 	}
 
-	subCmds, _ := s.logMeta["sub_commands"].([]interface{})
+	subCmds, _ := s.logMeta["sub_commands"].([]any)
 	subCmds = append(subCmds, entry)
 	s.logMeta["sub_commands"] = subCmds
 
@@ -1092,7 +1092,7 @@ func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.Serve
 
 // handleSubCommandReject records a sub-command reject event in the session metadata.
 func (s *Session) handleSubCommandReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, error) {
-	entry := map[string]interface{}{
+	entry := map[string]any{
 		"event_type": "reject",
 		"reason":     rejectMsg.GetReason(),
 	}
@@ -1101,7 +1101,7 @@ func (s *Session) handleSubCommandReject(rejectMsg *pb.RejectMessage) (*pb.Serve
 	}
 
 	// Extract info messages
-	infoMap := make(map[string]interface{})
+	infoMap := make(map[string]any)
 	for _, info := range rejectMsg.GetInfoMsgs() {
 		key := info.GetKey()
 		switch v := info.Value.(type) {
@@ -1123,7 +1123,7 @@ func (s *Session) handleSubCommandReject(rejectMsg *pb.RejectMessage) (*pb.Serve
 		}
 	}
 
-	subCmds, _ := s.logMeta["sub_commands"].([]interface{})
+	subCmds, _ := s.logMeta["sub_commands"].([]any)
 	subCmds = append(subCmds, entry)
 	s.logMeta["sub_commands"] = subCmds
 
@@ -1224,7 +1224,7 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 		timingFile.Close()
 		return nil, fmt.Errorf("failed to open log.json for restart: %w", err)
 	}
-	logMeta := make(map[string]interface{})
+	logMeta := make(map[string]any)
 	if err := json.NewDecoder(logJSONFile).Decode(&logMeta); err != nil {
 		logJSONFile.Close()
 		timingFile.Close()
@@ -1283,8 +1283,8 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 	}
 
 	// Record restart event in log.json
-	restarts, _ := logMeta["restarts"].([]interface{})
-	restartEntry := map[string]interface{}{
+	restarts, _ := logMeta["restarts"].([]any)
+	restartEntry := map[string]any{
 		"time": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	if resumePoint := restartMsg.GetResumePoint(); resumePoint != nil {

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -760,7 +760,7 @@ func TestStorageSession(t *testing.T) {
 		_, _ = session.HandleClientMessage(acceptClientMsg)
 
 		// Send multiple sub-commands
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			subCmdMsg := &pb.ClientMessage{
 				Type: &pb.ClientMessage_AcceptMsg{
 					AcceptMsg: &pb.AcceptMessage{
@@ -833,7 +833,7 @@ func TestCommitPointThrottling(t *testing.T) {
 	}
 
 	// Subsequent events within the 10s window should NOT return commit points
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		resp, err := session.HandleClientMessage(makeIoMsg())
 		if err != nil {
 			t.Fatalf("I/O event %d failed: %v", i+2, err)

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -101,7 +101,7 @@ func TestStorageSession(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read log.json: %v", err)
 		}
-		var logMeta map[string]interface{}
+		var logMeta map[string]any
 		if err := json.Unmarshal(data, &logMeta); err != nil {
 			t.Fatalf("Failed to unmarshal log.json: %v", err)
 		}
@@ -528,7 +528,7 @@ func TestStorageSession(t *testing.T) {
 			t.Fatalf("Failed to read log.json: %v", err)
 		}
 
-		var logMeta map[string]interface{}
+		var logMeta map[string]any
 		if err := json.Unmarshal(data, &logMeta); err != nil {
 			t.Fatalf("Failed to unmarshal log.json: %v", err)
 		}
@@ -587,16 +587,16 @@ func TestStorageSession(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read log.json: %v", err)
 		}
-		var logMeta map[string]interface{}
+		var logMeta map[string]any
 		if err := json.Unmarshal(data, &logMeta); err != nil {
 			t.Fatalf("Failed to unmarshal log.json: %v", err)
 		}
 
-		alerts, ok := logMeta["alerts"].([]interface{})
+		alerts, ok := logMeta["alerts"].([]any)
 		if !ok || len(alerts) != 1 {
 			t.Fatalf("Expected 1 alert in log.json, got %v", logMeta["alerts"])
 		}
-		alert := alerts[0].(map[string]interface{})
+		alert := alerts[0].(map[string]any)
 		if alert["reason"] != "policy violation detected" {
 			t.Errorf("Expected alert reason 'policy violation detected', got '%v'", alert["reason"])
 		}
@@ -651,14 +651,14 @@ func TestStorageSession(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read log.json: %v", err)
 		}
-		var logMeta map[string]interface{}
+		var logMeta map[string]any
 		json.Unmarshal(data, &logMeta)
 
-		subCmds, ok := logMeta["sub_commands"].([]interface{})
+		subCmds, ok := logMeta["sub_commands"].([]any)
 		if !ok || len(subCmds) != 1 {
 			t.Fatalf("Expected 1 sub_command, got %v", logMeta["sub_commands"])
 		}
-		subCmd := subCmds[0].(map[string]interface{})
+		subCmd := subCmds[0].(map[string]any)
 		if subCmd["event_type"] != "accept" {
 			t.Errorf("Expected event_type 'accept', got '%v'", subCmd["event_type"])
 		}
@@ -718,14 +718,14 @@ func TestStorageSession(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read log.json: %v", err)
 		}
-		var logMeta map[string]interface{}
+		var logMeta map[string]any
 		json.Unmarshal(data, &logMeta)
 
-		subCmds, ok := logMeta["sub_commands"].([]interface{})
+		subCmds, ok := logMeta["sub_commands"].([]any)
 		if !ok || len(subCmds) != 1 {
 			t.Fatalf("Expected 1 sub_command, got %v", logMeta["sub_commands"])
 		}
-		subCmd := subCmds[0].(map[string]interface{})
+		subCmd := subCmds[0].(map[string]any)
 		if subCmd["event_type"] != "reject" {
 			t.Errorf("Expected event_type 'reject', got '%v'", subCmd["event_type"])
 		}
@@ -783,10 +783,10 @@ func TestStorageSession(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read log.json: %v", err)
 		}
-		var logMeta map[string]interface{}
+		var logMeta map[string]any
 		json.Unmarshal(data, &logMeta)
 
-		subCmds, ok := logMeta["sub_commands"].([]interface{})
+		subCmds, ok := logMeta["sub_commands"].([]any)
 		if !ok || len(subCmds) != 3 {
 			t.Fatalf("Expected 3 sub_commands, got %d", len(subCmds))
 		}
@@ -1412,7 +1412,7 @@ func TestDefaultValuesForAbsentFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read log.json: %v", err)
 	}
-	var logMeta map[string]interface{}
+	var logMeta map[string]any
 	if err := json.Unmarshal(data, &logMeta); err != nil {
 		t.Fatalf("Failed to unmarshal log.json: %v", err)
 	}


### PR DESCRIPTION
## Summary

Bounds the graceful-shutdown path so SIGTERM actually causes the process to
exit, fixes the log_id used in slog so operators can correlate log entries with
session artefacts, and applies a batch of code-review follow-ups (modernization,
dedup, factory routing, worker pool, metric alignment).

The branch is structured as one logical change per commit so each can be read,
reverted, or cherry-picked independently.

## Commits (read bottom-up)

- **deps: bump google.golang.org/protobuf to v1.36.11** — routine patch update,
  also drops the now-unused \`golang.org/x/xerrors\` transitive.
- **server: bound graceful shutdown and align log_id used in slog** — the four
  Must-Fix items from the review: \`Wait\` now accepts a \`shutdownTimeout\` and
  caps \`waitGroup.Wait\` with a select+timer; the three handler-side
  \`WriteServerMessage\` calls switch to the \`Context\` variant so a stalled
  client cannot pin the handler past cancellation; \`acceptLoop\`'s 100ms
  post-error backoff is now ctx-aware; \`h.logID\` is refreshed from the
  session's authoritative base64 LogID after creation.
- **all: replace interface{} with any** — mechanical sweep.
- **all: modernize to Go 1.25 stdlib idioms** — \`slices.SortFunc\`,
  \`slices.Contains\`, range-over-int, \`sync.WaitGroup.Go\`.
- **tests: switch to t.Context() for test-scoped context** — five sites.
- **protocol: extract InfoMsgsToMap, dedup six call sites** — the
  \`InfoMessage\`→map conversion was reimplemented seven times. Consolidated
  behind one helper; also clears the dead \`entry[\"event_type\"] = \"…\"\`
  reassignments in EventSession that existed only to compensate for the old
  pattern overwriting authoritative fields.
- **connection: route NewEventSession through sessionFactories** —
  \`handleEventOnlyAccept\`'s local branch was the only session-creation site
  bypassing the mock-injection seam.
- **relay: bound RecoverOrphans concurrency with a worker pool** — was
  spawning one goroutine per cache file; with a multi-day-old cache that
  scales unboundedly.
- **metrics: align activeSessions with registry for relay sessions** — metric
  used to drop on client disconnect while registry kept the session as
  \`phase: flushing\`. Decrement now fires from the relay's onDone callback.

## Operator-visible behaviour changes

- **Process now exits within \`shutdownTimeout\` (30s) of SIGTERM** even when a
  handler is wedged. Previous behaviour was to block forever.
- **\`active_sessions\` metric for relay mode** now reflects sessions still
  consuming server resources (cache file + flusher goroutine) rather than only
  client-attached sessions. In steady state the metric can be non-zero
  briefly after the last client disconnects, until upstream flushes drain.
- **slog \`log_id\` field** now matches the on-disk and management-API value
  (base64) instead of the raw UUID string.

## Things explicitly NOT in this branch

- Should-Fix #12 (templated reject path): deferred per design discussion —
  RejectMessage may lack fields the template references, warrants its own pass.
- Review item #13 (writeMessage buffer pooling), #15 (writeNewFile fsync),
  #16 (math.Pow → bit-shift), #18 (\`appVersion\` from -ldflags), #20-#23:
  Consider items, not addressed here.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 -timeout 120s ./...\` clean on all packages
  (api, config, connection, metrics, protocol, relay, server, sessions, storage)
- [x] goleak-guarded suites (connection, relay, server) pass — no goroutine
  leaks introduced
- [ ] Manual: send SIGTERM to a running server with an active relay flush —
  process should exit within 30s
- [ ] Manual: inspect slog output and confirm \`log_id\` matches the value
  returned by the management API