### PR TITLE
Close CodeQL alert #4 by aligning relay writeProtoMessage pattern

### DIFF
--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -636,15 +636,11 @@ func writeProtoMessage(w io.Writer, msg *pb.ClientMessage) error {
 	if err != nil {
 		return err
 	}
-	l := len(data)
-	if l > protocol.MaxMessageSize {
-		return fmt.Errorf("message too large: length %d exceeds limit of %d", l, protocol.MaxMessageSize)
+	if len(data) > protocol.MaxMessageSize {
+		return fmt.Errorf("message too large: length %d exceeds limit of %d", len(data), protocol.MaxMessageSize)
 	}
-	if l > math.MaxInt-4 {
-		return fmt.Errorf("message too large: length %d overflows framed allocation", l)
-	}
-	buf := make([]byte, 4+l)
-	binary.BigEndian.PutUint32(buf[:4], uint32(l))
+	buf := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(buf[:4], uint32(len(data)))
 	copy(buf[4:], data)
 	_, err = w.Write(buf)
 	return err


### PR DESCRIPTION
## Why

CodeQL has been re-flagging the `make([]byte, 4+l)` allocation in `internal/relay/session.go:writeProtoMessage` as `go/allocation-size-overflow` (CWE-190, security severity HIGH) since 2026-02-16. Two earlier autofix attempts (commits `0144201`, `845d050`) added a `math.MaxInt-4` overflow guard but the alert kept reopening.

Meanwhile the semantically identical write path in `internal/protocol/processor.go:236` (`make([]byte, 4+len(outBytes))` after only a `MaxMessageSize` check) has never been flagged.

## Approach

The difference between the two call sites is the intermediate variable `l := len(data)` on the relay side. CodeQL's data-flow analysis tracks the `MaxMessageSize` bound through the direct `len()` call but loses it through the copy into a local int, so it cannot prove the addition is safe.

The `math.MaxInt-4` guard the autofix added was mathematically redundant — `MaxMessageSize` is 2 MiB, so `4 + len(data)` is bounded around seven orders of magnitude below `math.MaxInt` on every supported platform. Removing the dead guard is preferable to leaving a misleading branch in production code.

The fix aligns `writeProtoMessage` with the proven-working pattern from `processor.go`: drop the intermediate `l`, drop the redundant `MaxInt-4` check, use `len(data)` inline at both bounds-check and allocation. This both satisfies CodeQL and makes the two writers consistent.

## How it works

```go
// before
l := len(data)
if l > protocol.MaxMessageSize { return err }
if l > math.MaxInt-4 { return err }
buf := make([]byte, 4+l)

// after
if len(data) > protocol.MaxMessageSize { return err }
buf := make([]byte, 4+len(data))
```

`math` import is retained — still used for `math.Pow` in the relay reconnect backoff.

Verification:
- `go build ./...` clean
- `go vet ./internal/relay/` clean
- Full test suite passes (`go test -timeout 30s ./...`)

## Links

- CodeQL alert: https://github.com/pkilar/sudosrv-go/security/code-scanning/4