### PR TITLE
Add CI, Go Report Card, and Go Reference badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go Sudo I/O Log Server
 
+[![CI][ci-badge]][ci] [![Go Report Card][go-reportcard-badge]][go-reportcard] [![Go Reference][pkg.go.dev-badge]][pkg.go.dev]
+
 A high-performance, standalone I/O log server for sudo, written in Go. It is a fully compatible alternative to sudo's native `sudo_logsrvd`, capable of receiving and processing I/O logs from any sudo client (version 1.9.0+).
 
 The server captures complete transcripts of user sessions run via sudo, including all terminal input and output, providing a tool for security auditing, forensic analysis, and troubleshooting.
@@ -222,3 +224,10 @@ pkg/sudosrv_proto/   Generated protobuf definitions
 ## License
 
 See [LICENSE](LICENSE) for details.
+
+[ci-badge]: https://github.com/pkilar/sudosrv-go/actions/workflows/makefile.yml/badge.svg
+[ci]: https://github.com/pkilar/sudosrv-go/actions/workflows/makefile.yml
+[go-reportcard-badge]: https://goreportcard.com/badge/github.com/pkilar/sudosrv-go
+[go-reportcard]: https://goreportcard.com/report/github.com/pkilar/sudosrv-go
+[pkg.go.dev-badge]: https://pkg.go.dev/badge/github.com/pkilar/sudosrv-go.svg
+[pkg.go.dev]: https://pkg.go.dev/github.com/pkilar/sudosrv-go


### PR DESCRIPTION
## Why

Status badges give first-time visitors an at-a-glance signal about build health, code quality, and where to find generated API docs without having to dig through the Actions tab or guess the pkg.go.dev URL.

## Approach

Use reference-style markdown for the three badges so the prominent line at the top of the README stays compact (`[![CI][ci-badge]][ci] ...`) and all of the badge/link URLs are grouped together at the bottom of the file. Easier to read in raw form and easier to add/remove badges later without churning the top of the file.

Three badges chosen:
- **CI** — points at the existing `.github/workflows/makefile.yml` workflow (`Makefile CI`).
- **Go Report Card** — `goreportcard.com/report/github.com/pkilar/sudosrv-go`.
- **Go Reference** — `pkg.go.dev/github.com/pkilar/sudosrv-go`.

## How it works

- Inserts the badge line directly under the `# Go Sudo I/O Log Server` title.
- Appends six reference definitions after the License section (one shield URL + one click-through URL per badge).
- No other content changes.

## Known follow-up

`go.mod` currently declares `module sudosrv` rather than `module github.com/pkilar/sudosrv-go`. The CI badge works immediately because it only depends on the workflow file path, but **Go Report Card** and **Go Reference** both `go get` the module by its declared path, so until the module is renamed those two badges will render but click through to "path/repo not found". Renaming the module + updating all internal imports is a larger, separate change.