### PR TITLE
Multi-subsystem review fixes: security defaults, race fixes, hot-path cleanup

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,12 +9,14 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -23,6 +25,10 @@ import (
 	"sudosrv/internal/sessions"
 	"time"
 )
+
+// maxAPIRequestBody caps inbound request bodies. The API only serves GETs,
+// so an honest client sends no body; any oversized payload is hostile.
+const maxAPIRequestBody = 4096
 
 // Server owns the management HTTP server. Construct with NewServer, then call
 // Listen synchronously to bind the address (so port-in-use and TLS load
@@ -33,7 +39,11 @@ type Server struct {
 	registry *sessions.Registry
 	httpSrv  *http.Server
 	listener net.Listener
-	token    string
+	// tokenHash is sha256(token). Comparing fixed-length digests with
+	// subtle.ConstantTimeCompare removes the length side-channel that the
+	// raw-token compare leaks (ConstantTimeCompare returns 0 immediately on
+	// length mismatch).
+	tokenHash [sha256.Size]byte
 }
 
 // NewServer validates the configuration, loads the bearer token, and prepares
@@ -50,19 +60,38 @@ func NewServer(cfg config.APIConfig, registry *sessions.Registry) (*Server, erro
 	if err != nil {
 		return nil, err
 	}
-	s := &Server{cfg: cfg, registry: registry, token: token}
+	s := &Server{cfg: cfg, registry: registry, tokenHash: sha256.Sum256([]byte(token))}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions", s.authMW(s.handleList))
 	mux.HandleFunc("GET /api/v1/sessions/{id}", s.authMW(s.handleGet))
 
 	s.httpSrv = &http.Server{
-		Addr:              cfg.ListenAddress,
-		Handler:           mux,
+		Addr:    cfg.ListenAddress,
+		Handler: limitBody(mux),
+		// Header timeout protects against slow-header slowloris; the broader
+		// ReadTimeout/WriteTimeout cover slow-body and slow-receiver clients
+		// after the headers are consumed. MaxHeaderBytes caps a giant header
+		// flood before we allocate per-request buffers.
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 14, // 16 KiB; default 1 MiB is excessive for an admin API
 	}
 	return s, nil
+}
+
+// limitBody wraps every request body in a MaxBytesReader. The API is GET-only,
+// so 4 KiB is plenty for any conceivable future POST/PUT body and rejects
+// arbitrary-size hostile bodies before they can chew up memory.
+func limitBody(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxAPIRequestBody)
+		}
+		h.ServeHTTP(w, r)
+	})
 }
 
 // Listen synchronously binds the configured address and, if TLS is configured,
@@ -74,14 +103,11 @@ func (s *Server) Listen() error {
 		return errors.New("api: Listen called more than once")
 	}
 	if s.cfg.TLSCertFile != "" && s.cfg.TLSKeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(s.cfg.TLSCertFile, s.cfg.TLSKeyFile)
+		tlsCfg, err := buildTLSConfig(s.cfg)
 		if err != nil {
-			return fmt.Errorf("api: load tls keypair: %w", err)
+			return err
 		}
-		ln, err := tls.Listen("tcp", s.cfg.ListenAddress, &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS13,
-		})
+		ln, err := tls.Listen("tcp", s.cfg.ListenAddress, tlsCfg)
 		if err != nil {
 			return fmt.Errorf("api: listen on %s: %w", s.cfg.ListenAddress, err)
 		}
@@ -94,6 +120,21 @@ func (s *Server) Listen() error {
 	}
 	s.listener = ln
 	return nil
+}
+
+// buildTLSConfig centralizes TLS settings so future hardening (mTLS, OCSP
+// stapling, custom curve preferences) lives in one place. TLS 1.3 is the
+// floor — its cipher suites are not configurable and are all AEAD, so we
+// don't enumerate CipherSuites (those entries would be silently ignored).
+func buildTLSConfig(cfg config.APIConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("api: load tls keypair: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}, nil
 }
 
 // Serve handles HTTP requests on the listener bound by Listen. It blocks
@@ -141,6 +182,11 @@ func loadToken(cfg config.APIConfig) (string, error) {
 }
 
 // authMW enforces a constant-time bearer-token check on every request.
+// Both the configured token and the supplied token are hashed once with
+// SHA-256 before comparison so a) ConstantTimeCompare always operates on
+// equal-length inputs (the raw compare leaks "your token is wrong length"
+// via early return) and b) timing is independent of how long the attacker's
+// guess happens to be.
 func (s *Server) authMW(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		const prefix = "Bearer "
@@ -149,8 +195,8 @@ func (s *Server) authMW(next http.HandlerFunc) http.HandlerFunc {
 			writeError(w, http.StatusUnauthorized, "missing or malformed Authorization header")
 			return
 		}
-		provided := h[len(prefix):]
-		if subtle.ConstantTimeCompare([]byte(provided), []byte(s.token)) != 1 {
+		provided := sha256.Sum256([]byte(h[len(prefix):]))
+		if subtle.ConstantTimeCompare(provided[:], s.tokenHash[:]) != 1 {
 			writeError(w, http.StatusUnauthorized, "invalid token")
 			return
 		}
@@ -254,6 +300,11 @@ func summarize(info sessions.SessionInfo) sessionSummary {
 }
 
 func detail(info sessions.SessionInfo) sessionDetail {
+	// Defensive copy of the Info map: SessionInfo is stored by value in the
+	// registry but Info is a reference type, so a handler mutating the
+	// returned map would race with concurrent registry reads. maps.Clone
+	// keeps the API immutable from the caller's perspective.
+	infoCopy := maps.Clone(info.Info)
 	out := sessionDetail{
 		SessionID:    info.SessionID,
 		ServerLogID:  info.ServerLogID,
@@ -262,7 +313,7 @@ func detail(info sessions.SessionInfo) sessionDetail {
 		StartedAt:    info.StartedAt,
 		SubmitTime:   info.SubmitTime,
 		ExpectIobufs: info.ExpectIobufs,
-		Info:         info.Info,
+		Info:         infoCopy,
 	}
 	if info.Provider != nil {
 		s := info.Provider.LiveStats()
@@ -278,24 +329,39 @@ func detail(info sessions.SessionInfo) sessionDetail {
 	return out
 }
 
+// jsonInternalErrorBody is the canned response written when JSON encoding
+// itself fails. Hoisted to package level to avoid a per-error allocation.
+var jsonInternalErrorBody = []byte(`{"error":"internal server error"}` + "\n")
+
 // writeJSON marshals body into a buffer first so an encoding failure can
 // produce a 500 response instead of a 200 with truncated JSON. Once
 // WriteHeader has fired, the status is locked and the client will see
 // whatever we already wrote.
+//
+// Cache-Control: no-store keeps an authenticated session listing out of
+// shared caches; X-Content-Type-Options: nosniff prevents content sniffing
+// from reinterpreting the JSON payload.
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(body); err != nil {
 		slog.Error("api: failed to encode JSON response", "error", err)
-		w.Header().Set("Content-Type", "application/json")
+		setSecurityHeaders(w)
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":"internal server error"}` + "\n"))
+		_, _ = w.Write(jsonInternalErrorBody)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	setSecurityHeaders(w)
 	w.WriteHeader(status)
 	if _, err := w.Write(buf.Bytes()); err != nil {
 		slog.Error("api: failed to write JSON response", "error", err)
 	}
+}
+
+func setSecurityHeaders(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("Content-Type", "application/json")
+	h.Set("Cache-Control", "no-store")
+	h.Set("X-Content-Type-Options", "nosniff")
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -157,18 +157,34 @@ func TestAuth_RejectsWrongScheme(t *testing.T) {
 }
 
 func TestAuth_RejectsWrongToken(t *testing.T) {
-	srv, _ := newTestServer(t, "secret")
-	ts := withTestServer(t, srv)
-
-	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
-	req.Header.Set("Authorization", "Bearer wrong")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET: %v", err)
+	// Covers two cases: a different-length wrong token (the easy case the
+	// constant-time compare's length check short-circuits) AND a same-length
+	// wrong token (which exercises the equal-length compare path). A future
+	// "optimization" that replaces the constant-time compare with == would
+	// still pass the former; the latter is what catches that regression.
+	cases := []struct {
+		name    string
+		token   string
+	}{
+		{"different length", "wrong"},
+		{"same length, single char differs", "sxcret"},
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newTestServer(t, "secret")
+			ts := withTestServer(t, srv)
+
+			req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/api/v1/sessions", nil)
+			req.Header.Set("Authorization", "Bearer "+tc.token)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -143,7 +143,7 @@ func TestAuth_RejectsWrongScheme(t *testing.T) {
 	srv, _ := newTestServer(t, "secret")
 	ts := withTestServer(t, srv)
 
-	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/api/v1/sessions", nil)
 	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -192,7 +192,7 @@ func TestAuth_AcceptsCorrectToken(t *testing.T) {
 	srv, _ := newTestServer(t, "secret")
 	ts := withTestServer(t, srv)
 
-	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/api/v1/sessions", nil)
 	req.Header.Set("Authorization", "Bearer secret")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -304,7 +304,7 @@ func TestGet_NotFound(t *testing.T) {
 	srv, _ := newTestServer(t, "tok")
 	ts := withTestServer(t, srv)
 
-	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions/missing", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/api/v1/sessions/missing", nil)
 	req.Header.Set("Authorization", "Bearer tok")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -325,7 +325,7 @@ func TestMethodNotAllowed(t *testing.T) {
 	srv, _ := newTestServer(t, "tok")
 	ts := withTestServer(t, srv)
 
-	req, _ := http.NewRequest("POST", ts.URL+"/api/v1/sessions", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/api/v1/sessions", nil)
 	req.Header.Set("Authorization", "Bearer tok")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -339,7 +339,7 @@ func TestMethodNotAllowed(t *testing.T) {
 
 func authedGet(t *testing.T, url, token string) []byte {
 	t.Helper()
-	req, _ := http.NewRequest("GET", url, nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -74,16 +75,15 @@ type LocalStorageConfig struct {
 	PasswordFilter  bool   `yaml:"password_filter"`  // Enable regex-based password filtering
 }
 
-// LoadConfig reads the configuration from a YAML file.
+// LoadConfig reads the configuration from a YAML file. A missing file is an
+// error so a typo in -config or a missing deployment artifact cannot silently
+// replace the documented secure defaults with whatever yaml.v3 leaves in a
+// half-populated struct.
 func LoadConfig(path string) (*Config, error) {
 	config := defaultConfig()
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			slog.Warn("Config file not found, using defaults", "path", path)
-			return config, nil
-		}
 		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
 	}
 
@@ -94,24 +94,20 @@ func LoadConfig(path string) (*Config, error) {
 	return config, nil
 }
 
-// LoadConfigRequired reads the configuration from a YAML file and fails if the
-// file is missing. This is used for SIGHUP reloads so a transient deployment
-// mistake cannot silently replace the running config with defaults.
+// LoadConfigRequired is retained as an alias for LoadConfig so existing SIGHUP
+// reload call sites do not need to change. Both functions now have identical
+// fail-fast semantics on a missing file.
 func LoadConfigRequired(path string) (*Config, error) {
-	config := defaultConfig()
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
-	}
-
-	if err := unmarshalConfig(data, config); err != nil {
-		return nil, err
-	}
-
-	return config, nil
+	return LoadConfig(path)
 }
 
+// defaultConfig returns a Config populated with all secure defaults.
+//
+// LoadConfig calls this first, then yaml.Unmarshal merges user values on top.
+// yaml.v3 only overwrites fields that appear in the YAML, so any field the
+// user omits keeps its default — including PasswordFilter, IologDir, etc.
+// applyZeroValueDefaults is a defensive second pass that re-applies the few
+// numeric defaults a user could accidentally zero out (e.g., idle_timeout: 0).
 func defaultConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
@@ -217,6 +213,34 @@ func Validate(cfg *Config) error {
 		if (cfg.API.TLSCertFile == "") != (cfg.API.TLSKeyFile == "") {
 			return fmt.Errorf("api.tls_cert_file and api.tls_key_file must both be set or both empty")
 		}
+		if err := validateAuthTokenFile(cfg.API.AuthTokenFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateAuthTokenFile enforces the security preconditions documented for the
+// preferred AuthTokenFile credential path: absolute path, file exists, and the
+// mode forbids group/other access. A world-readable token file accepted as
+// "preferred" would be a silent regression.
+func validateAuthTokenFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("api.auth_token_file must be an absolute path, got %q", path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("api.auth_token_file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("api.auth_token_file %s is not a regular file", path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("api.auth_token_file %s has mode 0%o; require 0600 or 0400 (no group/other access)",
+			path, info.Mode().Perm())
 	}
 	return nil
 }
@@ -239,6 +263,12 @@ func ValidatePermissions(cfg *LocalStorageConfig) error {
 	if cfg.FilePermissions&0004 != 0 {
 		return fmt.Errorf("file_permissions 0%o is world-readable; sudo transcripts may contain secrets — refusing to start", cfg.FilePermissions)
 	}
+	// Directories without owner-exec are not traversable; this catches the
+	// classic `dir_permissions: 644` mistake (auto-octalled from decimal),
+	// which would otherwise produce inscrutable runtime errors.
+	if cfg.DirPermissions&0100 == 0 {
+		return fmt.Errorf("dir_permissions 0%o lacks owner-exec bit; directories would not be traversable", cfg.DirPermissions)
+	}
 	return nil
 }
 
@@ -247,6 +277,10 @@ func ValidatePermissions(cfg *LocalStorageConfig) error {
 // octal value (0o750 = 488). Only converts when every decimal digit is 0-7,
 // which is a strong signal the user intended octal notation. Values already
 // within 0-0o777 (0-511) are returned unchanged.
+//
+// ValidatePermissions runs after this conversion, so any resulting value that
+// would be unsafe (world-writable, world-readable file, dir without owner-exec)
+// still blocks startup with a clear error.
 func reinterpretDecimalAsOctal(val uint32, fieldName string) uint32 {
 	if val <= 0o777 {
 		return val // Already a valid permission value
@@ -259,14 +293,16 @@ func reinterpretDecimalAsOctal(val uint32, fieldName string) uint32 {
 		digit := tmp % 10
 		if digit > 7 {
 			// Contains 8 or 9 — not an octal literal, just a bad value
-			slog.Warn(fmt.Sprintf("%s value %d exceeds maximum 0777 and contains non-octal digits; please use quoted octal (e.g., 0o750)", fieldName, val))
+			slog.Warn("permission value exceeds 0777 and contains non-octal digits; use quoted octal (e.g., \"0750\")",
+				"field", fieldName, "value", val)
 			return val
 		}
 		octalVal += digit * multiplier
 		multiplier *= 8
 		tmp /= 10
 	}
-	slog.Warn(fmt.Sprintf("%s: auto-corrected YAML 1.2 decimal %d to octal 0o%o (%d); consider using quoted 0o notation in config", fieldName, val, octalVal, octalVal))
+	slog.Warn("auto-corrected YAML 1.2 decimal to octal; quote the value in config to silence this warning",
+		"field", fieldName, "decimal", val, "octal", fmt.Sprintf("0o%o", octalVal))
 	return octalVal
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,22 +62,16 @@ local_storage:
 		}
 	})
 
-	t.Run("NonExistentConfigFile", func(t *testing.T) {
-		// Attempt to load a config file that does not exist
-		cfg, err := LoadConfig("non-existent-file.yaml")
-		if err != nil {
-			t.Fatalf("LoadConfig() with non-existent file should not error, but got: %v", err)
+	t.Run("NonExistentConfigFileErrors", func(t *testing.T) {
+		// A missing config file is an error: silently falling back to defaults
+		// would mask deployment typos and could replace a documented secure
+		// config with whatever yaml.v3 leaves in a half-populated struct.
+		_, err := LoadConfig("non-existent-file.yaml")
+		if err == nil {
+			t.Fatal("LoadConfig() with non-existent file should error, got nil")
 		}
-
-		// Check that default values are used
-		if cfg.Server.Mode != "local" {
-			t.Errorf("expected default server mode 'local', got '%s'", cfg.Server.Mode)
-		}
-		if cfg.Server.ListenAddress != "127.0.0.1:30343" {
-			t.Errorf("expected default listen_address '127.0.0.1:30343', got '%s'", cfg.Server.ListenAddress)
-		}
-		if cfg.LocalStorage.LogDirectory != "/var/log/gosudo-io" {
-			t.Errorf("expected default log_directory '/var/log/gosudo-io', got '%s'", cfg.LocalStorage.LogDirectory)
+		if !strings.Contains(err.Error(), "non-existent-file.yaml") {
+			t.Errorf("error should mention the missing path, got: %v", err)
 		}
 	})
 
@@ -141,6 +135,82 @@ local_storage:
 	}
 }
 
+// TestPartialYAMLPreservesSecureDefaults pins yaml.v3's "leave unmentioned
+// fields alone" behavior for the fields that would silently flip a server
+// into an unsafe configuration if zeroed: password filter, log paths, server
+// ID, listen address, relay cache dir, and reconnect retries.
+//
+// If you ever refactor LoadConfig's merge strategy, keep this test green.
+func TestPartialYAMLPreservesSecureDefaults(t *testing.T) {
+	t.Parallel()
+	// Only `server.mode` is set; every other key is absent from the YAML.
+	// All security-critical defaults must survive.
+	content := `
+server:
+  mode: "local"
+`
+	tmpFile := filepath.Join(t.TempDir(), "minimal.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"PasswordFilter", cfg.LocalStorage.PasswordFilter, true},
+		{"LogDirectory", cfg.LocalStorage.LogDirectory, "/var/log/gosudo-io"},
+		{"IologDir", cfg.LocalStorage.IologDir, "%{LIVEDIR}/%{user}"},
+		{"IologFile", cfg.LocalStorage.IologFile, "%{seq}"},
+		{"ServerID", cfg.Server.ServerID, "GoSudoLogSrv/1.0"},
+		{"ListenAddress", cfg.Server.ListenAddress, "127.0.0.1:30343"},
+		{"MaxConnections", cfg.Server.MaxConnections, 10000},
+		{"RelayCacheDirectory", cfg.Relay.RelayCacheDirectory, "/var/log/gosudo-relay-cache"},
+		{"ReconnectAttempts", cfg.Relay.ReconnectAttempts, -1},
+		{"TLSSkipVerify", cfg.Relay.TLSSkipVerify, false},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestPartialYAMLExplicitFalseHonored verifies that a user who explicitly
+// writes `password_filter: false` can still turn it off — the defaults-merge
+// must not override explicit user intent.
+func TestPartialYAMLExplicitFalseHonored(t *testing.T) {
+	t.Parallel()
+	content := `
+server:
+  mode: "local"
+local_storage:
+  password_filter: false
+  compress: true
+`
+	tmpFile := filepath.Join(t.TempDir(), "explicit.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LocalStorage.PasswordFilter {
+		t.Error("password_filter: false in YAML should disable the filter")
+	}
+	if !cfg.LocalStorage.Compress {
+		t.Error("compress: true in YAML should enable compression")
+	}
+}
+
 func TestValidate(t *testing.T) {
 	t.Parallel()
 	// validLocal returns a fresh, minimally-valid local-mode Config.
@@ -159,7 +229,7 @@ func TestValidate(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		mutate  func(*Config)
+		mutate  func(t *testing.T, c *Config)
 		wantErr string // substring match; "" means expect no error
 	}{
 		{
@@ -167,7 +237,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "valid relay mode",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.Mode = "relay"
 				c.Relay.UpstreamHost = "upstream:1234"
 				c.Relay.RelayCacheDirectory = "/tmp/cache"
@@ -175,7 +245,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "valid TLS-only listener",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.ListenAddress = ""
 				c.Server.ListenAddressTLS = "127.0.0.1:30344"
 				c.Server.TLSCertFile = "cert"
@@ -184,12 +254,12 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:    "invalid mode",
-			mutate:  func(c *Config) { c.Server.Mode = "magic" },
+			mutate:  func(_ *testing.T, c *Config) { c.Server.Mode = "magic" },
 			wantErr: "invalid server mode",
 		},
 		{
 			name: "no listen address",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.ListenAddress = ""
 				c.Server.ListenAddressTLS = ""
 			},
@@ -197,7 +267,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TLS listener without cert",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.ListenAddressTLS = "127.0.0.1:30344"
 				c.Server.TLSKeyFile = "key"
 			},
@@ -205,7 +275,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TLS listener without key",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.ListenAddressTLS = "127.0.0.1:30344"
 				c.Server.TLSCertFile = "cert"
 			},
@@ -213,7 +283,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "relay mode missing upstream_host",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.Mode = "relay"
 				c.Relay.RelayCacheDirectory = "/tmp/cache"
 			},
@@ -221,7 +291,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "relay mode missing relay_cache_directory",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.Server.Mode = "relay"
 				c.Relay.UpstreamHost = "upstream:1234"
 			},
@@ -229,28 +299,28 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "local mode bad permissions delegates to ValidatePermissions",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.LocalStorage.DirPermissions = 0777
 			},
 			wantErr: "world-writable",
 		},
 		{
 			name: "valid API with inline token",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.API.ListenAddress = "127.0.0.1:30345"
 				c.API.AuthToken = "secret"
 			},
 		},
 		{
-			name: "valid API with token file",
-			mutate: func(c *Config) {
+			name: "valid API with token file (mode 0600)",
+			mutate: func(t *testing.T, c *Config) {
 				c.API.ListenAddress = "127.0.0.1:30345"
-				c.API.AuthTokenFile = "/run/sudosrv/api.token"
+				c.API.AuthTokenFile = writeTokenFile(t, 0600)
 			},
 		},
 		{
 			name: "valid API with TLS",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.API.ListenAddress = "127.0.0.1:30345"
 				c.API.AuthToken = "secret"
 				c.API.TLSCertFile = "api.crt"
@@ -259,14 +329,14 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "API enabled without token rejects",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.API.ListenAddress = "127.0.0.1:30345"
 			},
 			wantErr: "neither api.auth_token nor api.auth_token_file",
 		},
 		{
 			name: "API TLS cert without key rejects",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.API.ListenAddress = "127.0.0.1:30345"
 				c.API.AuthToken = "secret"
 				c.API.TLSCertFile = "api.crt"
@@ -275,7 +345,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "API TLS key without cert rejects",
-			mutate: func(c *Config) {
+			mutate: func(_ *testing.T, c *Config) {
 				c.API.ListenAddress = "127.0.0.1:30345"
 				c.API.AuthToken = "secret"
 				c.API.TLSKeyFile = "api.key"
@@ -286,6 +356,38 @@ func TestValidate(t *testing.T) {
 			name: "API disabled by default",
 			// No mutation: validLocal() leaves API zero-valued. Should not error.
 		},
+		{
+			name: "API token file with relative path rejected",
+			mutate: func(_ *testing.T, c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthTokenFile = "relative/path"
+			},
+			wantErr: "must be an absolute path",
+		},
+		{
+			name: "API token file missing rejected",
+			mutate: func(_ *testing.T, c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthTokenFile = "/nonexistent/sudosrv/token"
+			},
+			wantErr: "auth_token_file",
+		},
+		{
+			name: "API token file world-readable rejected",
+			mutate: func(t *testing.T, c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthTokenFile = writeTokenFile(t, 0644)
+			},
+			wantErr: "no group/other access",
+		},
+		{
+			name: "API token file group-readable rejected",
+			mutate: func(t *testing.T, c *Config) {
+				c.API.ListenAddress = "127.0.0.1:30345"
+				c.API.AuthTokenFile = writeTokenFile(t, 0640)
+			},
+			wantErr: "no group/other access",
+		},
 	}
 
 	for _, tt := range tests {
@@ -293,7 +395,7 @@ func TestValidate(t *testing.T) {
 			t.Parallel()
 			cfg := validLocal()
 			if tt.mutate != nil {
-				tt.mutate(cfg)
+				tt.mutate(t, cfg)
 			}
 			err := Validate(cfg)
 			switch {
@@ -306,6 +408,23 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// writeTokenFile creates a real token file in t.TempDir() with the given mode,
+// so AuthTokenFile validation (which stats the file) has something concrete
+// to evaluate. Returns the absolute path.
+func writeTokenFile(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "api.token")
+	if err := os.WriteFile(path, []byte("secret\n"), mode); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	// WriteFile honours mode only on creation; chmod to be sure on filesystems
+	// where umask interferes.
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+	return path
 }
 
 func TestValidatePermissions(t *testing.T) {
@@ -322,6 +441,7 @@ func TestValidatePermissions(t *testing.T) {
 		{"world-writable file", 0750, 0642, "file_permissions"},
 		{"world-readable file", 0750, 0644, "world-readable"},
 		{"both bits bad on dir checked first", 0777, 0777, "dir_permissions"},
+		{"dir without owner-exec rejected", 0640, 0640, "owner-exec"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -467,6 +587,17 @@ func TestApplyZeroValueDefaults(t *testing.T) {
 		applyZeroValueDefaults(cfg)
 		if cfg.Server.MaxConnections != 0 {
 			t.Errorf("Negative MaxConnections should be normalized to 0, got %d", cfg.Server.MaxConnections)
+		}
+	})
+
+	t.Run("zero max_connections is preserved (disables cap)", func(t *testing.T) {
+		t.Parallel()
+		// "0 disables the cap" is documented behavior; applyZeroValueDefaults
+		// must not silently rewrite it to the 10000 default.
+		cfg := &Config{Server: ServerConfig{MaxConnections: 0}}
+		applyZeroValueDefaults(cfg)
+		if cfg.Server.MaxConnections != 0 {
+			t.Errorf("MaxConnections=0 must be preserved, got %d", cfg.Server.MaxConnections)
 		}
 	})
 

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -91,6 +91,12 @@ func NewHandler(conn net.Conn, cfg *config.Config) *Handler {
 // NewHandlerWithContext creates a new handler for a connection with context
 // support. Pass a non-nil registry to make the connection's session visible to
 // the management API; pass nil to disable that integration.
+//
+// The supplied cfg is captured by value for the lifetime of the connection:
+// SIGHUP-driven config changes (notably Server.IdleTimeout) only affect
+// connections accepted *after* the reload. The server's reload path explicitly
+// rejects listener/mode changes for that reason; numeric tuning knobs like
+// IdleTimeout become effective per-connection at next accept.
 func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Config, registry *sessions.Registry) *Handler {
 	_, isTLS := conn.(*tls.Conn)
 	h := &Handler{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,11 @@ import (
 // Metrics holds basic operational metrics for the server.
 // All counter fields use atomic.Int64 to enforce atomic access at the type level,
 // preventing accidental non-atomic reads or writes.
+//
+// serverStartUnixNano stores the start time as a single atomic int64 of unix
+// nanoseconds. Storing a time.Time directly would not be torn-write-safe — it's
+// a two-word struct, and a Reset() racing with GetUptime() could observe a
+// half-updated value.
 type Metrics struct {
 	totalConnections  atomic.Int64
 	activeConnections atomic.Int64
@@ -23,16 +28,16 @@ type Metrics struct {
 	messagesProcessed atomic.Int64
 	messageErrors     atomic.Int64
 
-	serverStartTime time.Time
+	serverStartUnixNano atomic.Int64
 }
 
 // Global metrics instance
 var Global = newMetrics()
 
 func newMetrics() *Metrics {
-	return &Metrics{
-		serverStartTime: time.Now(),
-	}
+	m := &Metrics{}
+	m.serverStartUnixNano.Store(time.Now().UnixNano())
+	return m
 }
 
 // Connection tracking
@@ -114,7 +119,7 @@ func (m *Metrics) GetMessageErrors() int64 {
 }
 
 func (m *Metrics) GetUptime() time.Duration {
-	return time.Since(m.serverStartTime)
+	return time.Since(time.Unix(0, m.serverStartUnixNano.Load()))
 }
 
 // Reset resets all counters to zero. Intended for use in tests.
@@ -128,5 +133,5 @@ func (m *Metrics) Reset() {
 	m.relaySessions.Store(0)
 	m.messagesProcessed.Store(0)
 	m.messageErrors.Store(0)
-	m.serverStartTime = time.Now()
+	m.serverStartUnixNano.Store(time.Now().UnixNano())
 }

--- a/internal/protocol/infomsg.go
+++ b/internal/protocol/infomsg.go
@@ -2,15 +2,20 @@
 // Filename: internal/protocol/infomsg.go
 package protocol
 
-import pb "sudosrv/pkg/sudosrv_proto"
+import (
+	"fmt"
+	"log/slog"
+
+	pb "sudosrv/pkg/sudosrv_proto"
+)
 
 // InfoMsgsToMap converts a slice of InfoMessage entries to a generic map keyed
 // by InfoMessage.Key. Entries with empty keys are skipped (matching C
 // sudo_logsrvd, which treats keyless entries as malformed). Strval, Numval, and
 // Strlistval values are unwrapped to their underlying Go types (string, int64,
-// []string). Unknown value variants are silently dropped — this keeps the
-// helper forward-compatible if the proto schema grows new InfoMessage value
-// types in a future sudo release.
+// []string). Unknown value variants are dropped (preserving forward-compat with
+// future proto extensions) but logged at Debug so a new field doesn't quietly
+// disappear from audit records.
 func InfoMsgsToMap(infos []*pb.InfoMessage) map[string]any {
 	out := make(map[string]any, len(infos))
 	for _, info := range infos {
@@ -25,6 +30,9 @@ func InfoMsgsToMap(infos []*pb.InfoMessage) map[string]any {
 			out[key] = v.Numval
 		case *pb.InfoMessage_Strlistval:
 			out[key] = v.Strlistval.GetStrings()
+		default:
+			slog.Debug("InfoMessage variant dropped (unknown type)",
+				"key", key, "type", fmt.Sprintf("%T", v))
 		}
 	}
 	return out

--- a/internal/protocol/processor.go
+++ b/internal/protocol/processor.go
@@ -64,6 +64,10 @@ func NewProcessorWithCloser(r io.Reader, w io.Writer, c io.Closer) Processor {
 	}
 }
 
+// withReadContext runs fn() and aborts the underlying read promptly when ctx
+// is cancelled. For non-cancellable contexts (context.Background()), where
+// ctx.Done() returns nil, the watcher goroutine is skipped entirely — this
+// saves 2 channels + 1 goroutine per protocol message on the common hot path.
 func withReadContext(ctx context.Context, reader io.Reader, fn func() error) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -73,7 +77,10 @@ func withReadContext(ctx context.Context, reader io.Reader, fn func() error) err
 	}
 
 	setter, ok := reader.(readDeadlineSetter)
-	if !ok {
+	// Skip the watcher when (a) the reader cannot enforce a deadline or
+	// (b) the context cannot be cancelled. Either condition makes the
+	// watcher pure overhead.
+	if !ok || ctx.Done() == nil {
 		err := fn()
 		if err != nil && ctx.Err() != nil {
 			return ctx.Err()
@@ -102,6 +109,8 @@ func withReadContext(ctx context.Context, reader io.Reader, fn func() error) err
 	return err
 }
 
+// withWriteContext mirrors withReadContext for the write side; see that
+// function's godoc for the hot-path short-circuit rationale.
 func withWriteContext(ctx context.Context, writer io.Writer, fn func() error) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -111,7 +120,7 @@ func withWriteContext(ctx context.Context, writer io.Writer, fn func() error) er
 	}
 
 	setter, ok := writer.(writeDeadlineSetter)
-	if !ok {
+	if !ok || ctx.Done() == nil {
 		err := fn()
 		if err != nil && ctx.Err() != nil {
 			return ctx.Err()

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -58,11 +58,15 @@ type Session struct {
 	config           *config.RelayConfig
 	initialAcceptMsg *pb.AcceptMessage
 	fromClientChan   chan *pb.ClientMessage
-	// closed is closed by Close() to signal "no more sends will arrive".
-	// HandleClientMessage selects on it instead of relying on a closed
-	// fromClientChan, which would panic on send if a late call races with
-	// teardown (e.g. a metric reader holding a stale Session pointer).
-	closed    chan struct{}
+	// sendMu serializes Close against in-flight HandleClientMessage calls.
+	// HandleClientMessage holds RLock for its entire critical section
+	// (closed check + channel send); Close takes the exclusive Lock so it
+	// waits for every admitted send to commit to the channel before
+	// flipping the closed flag and closing the channel. Without this,
+	// a sender that passed the closed check could still write to a buffer
+	// the writer goroutine has already abandoned, silently losing audit data.
+	sendMu    sync.RWMutex
+	closed    atomic.Bool // mutated under sendMu.Lock; read under sendMu.RLock
 	wg        sync.WaitGroup
 	closeOnce sync.Once
 	cacheFileName   string
@@ -126,7 +130,6 @@ func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.Accept
 		config:           cfg,
 		initialAcceptMsg: acceptMsg,
 		fromClientChan:   make(chan *pb.ClientMessage, 1000), // Buffered channel for client messages
-		closed:           make(chan struct{}),
 		cacheFileName:    cacheFileName,
 		cumulativeDelay:  make(map[string]time.Duration),
 		ctx:              ctx,
@@ -251,11 +254,17 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 	}
 
 	// Loop until the session context is cancelled (server shutdown), Close()
-	// signals end-of-input, or an ExitMessage arrives. We drain any messages
-	// still buffered in fromClientChan after Close before exiting.
+	// closes fromClientChan, or an ExitMessage arrives. Close() guarantees
+	// that every admitted send has committed to the channel before close()
+	// fires, so the ok=false signal here implies "the buffer has been fully
+	// drained" — no messages are lost on disconnect races.
 	for {
 		select {
-		case msg := <-s.fromClientChan:
+		case msg, ok := <-s.fromClientChan:
+			if !ok {
+				// Channel closed by Close(); all buffered messages drained.
+				return false
+			}
 			if err := writeProtoMessage(file, msg); err != nil {
 				slog.Error("Failed to write message to relay cache, aborting write phase", "log_id", s.logID, "error", err)
 				return false
@@ -263,24 +272,6 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 			if _, ok := msg.Type.(*pb.ClientMessage_ExitMsg); ok {
 				slog.Debug("ExitMessage received and cached. Ending write phase.", "log_id", s.logID)
 				return true
-			}
-		case <-s.closed:
-			// Close() was called. Drain any buffered messages before exiting
-			// — they were sent before Close() returned and represent real
-			// client data we owe to the cache.
-			for {
-				select {
-				case msg := <-s.fromClientChan:
-					if err := writeProtoMessage(file, msg); err != nil {
-						slog.Error("Failed to write buffered message during drain", "log_id", s.logID, "error", err)
-						return false
-					}
-					if _, ok := msg.Type.(*pb.ClientMessage_ExitMsg); ok {
-						return true
-					}
-				default:
-					return false
-				}
 			}
 		case <-s.ctx.Done():
 			slog.Info("Relay session write phase cancelled by context", "log_id", s.logID)
@@ -370,13 +361,14 @@ func (s *Session) LiveStats() sessions.LiveStats {
 }
 
 func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
-	// Reject sends after Close() to avoid panicking on a closed channel. The
-	// closed check is in the select arm of the send below; this early check
-	// short-circuits the bookkeeping work for an already-closed session.
-	select {
-	case <-s.closed:
+	// RLock pairs with Close()'s Lock: while we hold this, Close cannot run
+	// to completion. Any send that admits past the closed check is therefore
+	// guaranteed to commit to the channel before close(fromClientChan) fires
+	// — the writer cannot miss it.
+	s.sendMu.RLock()
+	defer s.sendMu.RUnlock()
+	if s.closed.Load() {
 		return nil, fmt.Errorf("relay session closed")
-	default:
 	}
 
 	s.msgCount.Add(1)
@@ -400,8 +392,6 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 	case <-timer.C:
 		slog.Warn("Relay session message channel timeout", "log_id", s.logID)
 		return nil, fmt.Errorf("relay session message channel timeout")
-	case <-s.closed:
-		return nil, fmt.Errorf("relay session closed")
 	case <-s.ctx.Done():
 		return nil, fmt.Errorf("relay session cancelled")
 	}
@@ -438,14 +428,19 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 // returns immediately; durable upstream flushing continues in the background.
 // Server shutdown propagates via the parent context. Safe to call multiple times.
 //
-// We deliberately do NOT close fromClientChan — a late HandleClientMessage
-// call racing with Close would panic on send. Closing a dedicated signal
-// channel lets the runner detect end-of-input while keeping the data channel
-// in a panic-free state.
+// Acquiring sendMu exclusively waits for any HandleClientMessage call already
+// inside its critical section to finish its channel send. After we set
+// closed=true and close the channel, no new sender can pass the closed check
+// and any committed buffered message will be drained by the writer's
+// ok-from-receive loop. This is the synchronization Codex's adversarial
+// review identified as missing.
 func (s *Session) Close() error {
 	s.closeOnce.Do(func() {
 		slog.Info("Client connection closed. Relay session writer will now complete.", "log_id", s.logID)
-		close(s.closed)
+		s.sendMu.Lock()
+		s.closed.Store(true)
+		close(s.fromClientChan)
+		s.sendMu.Unlock()
 	})
 	return nil
 }

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -58,14 +58,19 @@ type Session struct {
 	config           *config.RelayConfig
 	initialAcceptMsg *pb.AcceptMessage
 	fromClientChan   chan *pb.ClientMessage
-	wg               sync.WaitGroup
-	closeOnce        sync.Once
-	cacheFileName    string
-	mu               sync.Mutex               // Protects cumulativeDelay and lastCommitTime
-	cumulativeDelay  map[string]time.Duration // Tracks cumulative I/O delay per stream for commit points
-	lastCommitTime   time.Time                // When last commit point was sent to client
-	ctx              context.Context
-	cancel           context.CancelFunc
+	// closed is closed by Close() to signal "no more sends will arrive".
+	// HandleClientMessage selects on it instead of relying on a closed
+	// fromClientChan, which would panic on send if a late call races with
+	// teardown (e.g. a metric reader holding a stale Session pointer).
+	closed    chan struct{}
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+	cacheFileName   string
+	mu              sync.Mutex               // Protects cumulativeDelay and lastCommitTime
+	cumulativeDelay map[string]time.Duration // Tracks cumulative I/O delay per stream for commit points
+	lastCommitTime  time.Time                // When last commit point was sent to client
+	ctx             context.Context
+	cancel          context.CancelFunc
 	// onDone is invoked exactly once after the background runner exits — i.e.
 	// after both the cache-write phase and any upstream-flush phase finish.
 	// Connection-side bookkeeping that needs to outlive the client connection
@@ -83,6 +88,9 @@ type Session struct {
 	phase         atomic.Pointer[string] // "writing" -> "flushing"
 }
 
+// Compile-time check that Session satisfies sessions.MetadataProvider.
+var _ sessions.MetadataProvider = (*Session)(nil)
+
 // IsDone reports whether the background runner has finished. Once true the
 // session will never call its onDone callback again; any registry or other
 // state that was added after onDone fired must be cleaned up by the caller.
@@ -98,7 +106,10 @@ func (s *Session) IsDone() bool { return s.done.Load() }
 // API registry entries) to the actual end of the session rather than the end
 // of the connection.
 func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig, onDone func()) (*Session, error) {
-	if err := os.MkdirAll(cfg.RelayCacheDirectory, 0750); err != nil {
+	// 0700: cache files and the directory carry raw sudo I/O (keystrokes,
+	// command output, sometimes passwords — the storage password filter
+	// does not apply to the relay cache writer). Group/other must not read.
+	if err := os.MkdirAll(cfg.RelayCacheDirectory, 0700); err != nil {
 		return nil, fmt.Errorf("could not create relay cache directory %s: %w", cfg.RelayCacheDirectory, err)
 	}
 
@@ -115,6 +126,7 @@ func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.Accept
 		config:           cfg,
 		initialAcceptMsg: acceptMsg,
 		fromClientChan:   make(chan *pb.ClientMessage, 1000), // Buffered channel for client messages
+		closed:           make(chan struct{}),
 		cacheFileName:    cacheFileName,
 		cumulativeDelay:  make(map[string]time.Duration),
 		ctx:              ctx,
@@ -158,6 +170,12 @@ func (s *Session) run() {
 	// Phase 2: The client session is complete. Now, persistently try to flush the file.
 	s.phase.Store(&phaseFlushing)
 	slog.Info("Client session complete, beginning persistent flush attempts.", "log_id", s.logID, "file", s.cacheFileName)
+	// Pre-connect splay (0–1s) so many concurrently-completing sessions don't
+	// all hit the upstream in lockstep when it comes back online. Per-session
+	// backoff already jitters; this addresses synchronized first attempts.
+	if err := sleepWithContext(s.ctx, time.Duration(rand.Int64N(int64(time.Second)))); err != nil {
+		return
+	}
 	for attempt := 0; s.config.ReconnectAttempts == -1 || attempt < s.config.ReconnectAttempts; attempt++ {
 		select {
 		case <-s.ctx.Done():
@@ -207,7 +225,9 @@ func (s *Session) run() {
 
 // writeMessagesToCache opens the cache file and writes all received messages until an ExitMessage.
 func (s *Session) writeMessagesToCache() (completed bool) {
-	file, err := os.OpenFile(s.cacheFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	// 0600: cache files carry raw sudo I/O, sometimes including passwords
+	// (the storage password filter is not applied to the relay write path).
+	file, err := os.OpenFile(s.cacheFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		slog.Error("CRITICAL: could not open cache file. Relay data for this session will be lost.", "log_id", s.logID, "error", err)
 		return
@@ -230,15 +250,12 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 		return
 	}
 
-	// Loop until the session context is cancelled (server shutdown), the client
-	// channel is closed (connection handler exited), or an ExitMessage arrives.
+	// Loop until the session context is cancelled (server shutdown), Close()
+	// signals end-of-input, or an ExitMessage arrives. We drain any messages
+	// still buffered in fromClientChan after Close before exiting.
 	for {
 		select {
-		case msg, ok := <-s.fromClientChan:
-			if !ok {
-				// Channel closed by Close(): the connection handler has exited.
-				return false
-			}
+		case msg := <-s.fromClientChan:
 			if err := writeProtoMessage(file, msg); err != nil {
 				slog.Error("Failed to write message to relay cache, aborting write phase", "log_id", s.logID, "error", err)
 				return false
@@ -246,6 +263,24 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 			if _, ok := msg.Type.(*pb.ClientMessage_ExitMsg); ok {
 				slog.Debug("ExitMessage received and cached. Ending write phase.", "log_id", s.logID)
 				return true
+			}
+		case <-s.closed:
+			// Close() was called. Drain any buffered messages before exiting
+			// — they were sent before Close() returned and represent real
+			// client data we owe to the cache.
+			for {
+				select {
+				case msg := <-s.fromClientChan:
+					if err := writeProtoMessage(file, msg); err != nil {
+						slog.Error("Failed to write buffered message during drain", "log_id", s.logID, "error", err)
+						return false
+					}
+					if _, ok := msg.Type.(*pb.ClientMessage_ExitMsg); ok {
+						return true
+					}
+				default:
+					return false
+				}
 			}
 		case <-s.ctx.Done():
 			slog.Info("Relay session write phase cancelled by context", "log_id", s.logID)
@@ -258,6 +293,22 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 // overflowing float64 into +Inf during infinite-reconnect runs. 2^62ns is
 // already ~146 years — well past any realistic maxInterval.
 const maxBackoffExponent = 62
+
+// sleepWithContext sleeps for d or returns ctx.Err() if cancellation arrives
+// first. Used for jitter splays that must respect server shutdown.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
 func (s *Session) calculateBackoff(attempts int) time.Duration {
 	maxInterval := s.config.MaxReconnectInterval
@@ -278,22 +329,23 @@ func (s *Session) calculateBackoff(attempts int) time.Duration {
 	return time.Duration(backoff)
 }
 
-// extractIoDelay extracts the stream name and delay from I/O buffer messages.
-// Returns ("", nil, false) for non-I/O messages.
-func extractIoDelay(msg *pb.ClientMessage) (string, *pb.TimeSpec, bool) {
+// extractIoDelay returns the stream name and delay for I/O buffer messages.
+// Returns ("", nil) for non-I/O messages; the empty stream name is the "not
+// applicable" signal — no separate ok bool is needed.
+func extractIoDelay(msg *pb.ClientMessage) (string, *pb.TimeSpec) {
 	switch event := msg.Type.(type) {
 	case *pb.ClientMessage_TtyinBuf:
-		return "ttyin", event.TtyinBuf.GetDelay(), true
+		return "ttyin", event.TtyinBuf.GetDelay()
 	case *pb.ClientMessage_TtyoutBuf:
-		return "ttyout", event.TtyoutBuf.GetDelay(), true
+		return "ttyout", event.TtyoutBuf.GetDelay()
 	case *pb.ClientMessage_StdinBuf:
-		return "stdin", event.StdinBuf.GetDelay(), true
+		return "stdin", event.StdinBuf.GetDelay()
 	case *pb.ClientMessage_StdoutBuf:
-		return "stdout", event.StdoutBuf.GetDelay(), true
+		return "stdout", event.StdoutBuf.GetDelay()
 	case *pb.ClientMessage_StderrBuf:
-		return "stderr", event.StderrBuf.GetDelay(), true
+		return "stderr", event.StderrBuf.GetDelay()
 	default:
-		return "", nil, false
+		return "", nil
 	}
 }
 
@@ -318,6 +370,15 @@ func (s *Session) LiveStats() sessions.LiveStats {
 }
 
 func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage, error) {
+	// Reject sends after Close() to avoid panicking on a closed channel. The
+	// closed check is in the select arm of the send below; this early check
+	// short-circuits the bookkeeping work for an already-closed session.
+	select {
+	case <-s.closed:
+		return nil, fmt.Errorf("relay session closed")
+	default:
+	}
+
 	s.msgCount.Add(1)
 	s.bytesReceived.Add(int64(proto.Size(msg)))
 	now := time.Now()
@@ -329,12 +390,18 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 		return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: s.logID}}, nil
 	}
 
-	// Use a timeout to prevent indefinite blocking
+	// Use a timeout to prevent indefinite blocking. time.NewTimer+Stop
+	// avoids leaking a pending timer for up to 5s on the common path where
+	// the send wins immediately (time.After cannot be stopped).
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 	select {
 	case s.fromClientChan <- msg:
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		slog.Warn("Relay session message channel timeout", "log_id", s.logID)
 		return nil, fmt.Errorf("relay session message channel timeout")
+	case <-s.closed:
+		return nil, fmt.Errorf("relay session closed")
 	case <-s.ctx.Done():
 		return nil, fmt.Errorf("relay session cancelled")
 	}
@@ -343,7 +410,7 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 	// throttled to commitPointInterval matching C sudo_logsrvd behavior.
 	// Lock protects cumulativeDelay and lastCommitTime which are also
 	// read by the run() goroutine's context (indirectly via Close/wg.Wait).
-	if streamName, delay, ok := extractIoDelay(msg); ok {
+	if streamName, delay := extractIoDelay(msg); streamName != "" {
 		s.mu.Lock()
 		if delay != nil {
 			delayDur := time.Duration(delay.TvSec)*time.Second + time.Duration(delay.TvNsec)*time.Nanosecond
@@ -355,8 +422,8 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 			s.mu.Unlock()
 			return &pb.ServerMessage{Type: &pb.ServerMessage_CommitPoint{
 				CommitPoint: &pb.TimeSpec{
-					TvSec:  int64(commitPoint.Seconds()),
-					TvNsec: int32(commitPoint.Nanoseconds() % 1e9),
+					TvSec:  int64(commitPoint / time.Second),
+					TvNsec: int32(commitPoint % time.Second),
 				},
 			}}, nil
 		}
@@ -370,10 +437,15 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 // signals the write-phase loop that no more messages will arrive and then
 // returns immediately; durable upstream flushing continues in the background.
 // Server shutdown propagates via the parent context. Safe to call multiple times.
+//
+// We deliberately do NOT close fromClientChan — a late HandleClientMessage
+// call racing with Close would panic on send. Closing a dedicated signal
+// channel lets the runner detect end-of-input while keeping the data channel
+// in a panic-free state.
 func (s *Session) Close() error {
 	s.closeOnce.Do(func() {
 		slog.Info("Client connection closed. Relay session writer will now complete.", "log_id", s.logID)
-		close(s.fromClientChan)
+		close(s.closed)
 	})
 	return nil
 }
@@ -408,6 +480,12 @@ func RecoverOrphans(ctx context.Context, cfg *config.RelayConfig) error {
 	for _, f := range flushingFiles {
 		restored := f[:len(f)-len(FlushingSuffix)]
 		if err := os.Rename(f, restored); err != nil {
+			if os.IsNotExist(err) {
+				// Another concurrent recovery (HA failover, parallel orphan
+				// scan) already claimed this file. Benign.
+				slog.Debug("Mid-flush cache file already claimed by another worker", "path", f)
+				continue
+			}
 			slog.Error("Failed to recover mid-flush cache file", "path", f, "error", err)
 			continue
 		}
@@ -476,9 +554,14 @@ func RecoverOrphans(ctx context.Context, cfg *config.RelayConfig) error {
 func FlushOrphanedFile(ctx context.Context, filePath string, cfg *config.RelayConfig) error {
 	slog.Info("Found orphaned relay file, attempting to flush", "path", filePath)
 
-	// Rename file to prevent another process from picking it up
+	// Rename file to prevent another process from picking it up. A missing
+	// file means a sibling worker already claimed it — benign skip.
 	flushingFileName := filePath + FlushingSuffix
 	if err := os.Rename(filePath, flushingFileName); err != nil {
+		if os.IsNotExist(err) {
+			slog.Debug("Orphan file already claimed by another worker", "path", filePath)
+			return nil
+		}
 		slog.Error("Could not rename orphaned file for flushing", "path", filePath, "error", err)
 		return fmt.Errorf("could not rename orphaned file %s: %w", filePath, err)
 	}

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -12,6 +12,7 @@ import (
 	"sudosrv/internal/protocol"
 	pb "sudosrv/pkg/sudosrv_proto"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ type mockUpstreamServer struct {
 	wg           sync.WaitGroup
 	receivedMsgs chan *pb.ClientMessage
 	t            *testing.T
+	closing      atomic.Bool // set true before listener.Close so acceptLoop suppresses the expected "use of closed network connection" log
 }
 
 func newMockUpstreamServer(t *testing.T, addr string) (*mockUpstreamServer, error) {
@@ -58,7 +60,7 @@ func (s *mockUpstreamServer) acceptLoop() {
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
-			if !s.isClosing() {
+			if !s.closing.Load() {
 				s.t.Logf("Accept error: %v", err)
 			}
 			return // Listener was closed
@@ -69,18 +71,6 @@ func (s *mockUpstreamServer) acceptLoop() {
 			s.handleConnection(c)
 		}(conn)
 	}
-}
-
-func (s *mockUpstreamServer) isClosing() bool {
-	// Check if listener is closed by trying to get the file descriptor
-	if tcpListener, ok := s.listener.(*net.TCPListener); ok {
-		file, err := tcpListener.File()
-		if err != nil {
-			return true // Likely closed
-		}
-		file.Close()
-	}
-	return false
 }
 
 // handleConnection now robustly handles the full handshake and subsequent message flush.
@@ -142,6 +132,7 @@ func (s *mockUpstreamServer) handleConnection(conn net.Conn) {
 }
 
 func (s *mockUpstreamServer) Close() {
+	s.closing.Store(true)
 	s.listener.Close()
 	s.wg.Wait()
 	close(s.receivedMsgs)
@@ -193,17 +184,25 @@ func TestRelaySession_CacheAndFlush(t *testing.T) {
 		t.Fatalf("NewSession() failed: %v", err)
 	}
 
-	// 4. Send some messages to the session, which will be cached locally
-	session.HandleClientMessage(&pb.ClientMessage{
+	// 4. Send some messages to the session, which will be cached locally.
+	// Errors here indicate a regression in HandleClientMessage (e.g. timeout,
+	// channel closed); failing loudly beats a silent miscount downstream.
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{
 		Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{Data: []byte("output1")}},
-	})
-	session.HandleClientMessage(&pb.ClientMessage{
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(output1): %v", err)
+	}
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{
 		Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{Data: []byte("output2")}},
-	})
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(output2): %v", err)
+	}
 	// Send the final exit message, which completes the client-facing part of the session
-	session.HandleClientMessage(&pb.ClientMessage{
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{
 		Type: &pb.ClientMessage_ExitMsg{ExitMsg: &pb.ExitMessage{ExitValue: 0}},
-	})
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(exit): %v", err)
+	}
 
 	// 5. Close the "client" connection to the relay session.
 	// This signals the messageWriter to finish, allowing the background flusher to proceed.
@@ -321,9 +320,11 @@ func TestRelayCommitPoints(t *testing.T) {
 	}
 
 	// Clean up: send exit and close
-	session.HandleClientMessage(&pb.ClientMessage{
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{
 		Type: &pb.ClientMessage_ExitMsg{ExitMsg: &pb.ExitMessage{ExitValue: 0}},
-	})
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(exit) during cleanup: %v", err)
+	}
 	session.Close()
 	waitRelaySession(t, session, 2*time.Second)
 }
@@ -367,7 +368,7 @@ func TestRelayCommitPointThrottling(t *testing.T) {
 	}
 
 	// Subsequent events within throttle window: no commit point
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		resp, err = session.HandleClientMessage(makeIoMsg())
 		if err != nil {
 			t.Fatalf("I/O event %d failed: %v", i+2, err)

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -4,6 +4,9 @@ package relay
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -435,4 +438,120 @@ func TestRelaySession_CloseDoesNotWaitForFlush(t *testing.T) {
 
 	cancel()
 	waitRelaySession(t, session, 2*time.Second)
+}
+
+// TestRelaySession_NoMessageLossUnderCloseRace asserts the invariant Codex's
+// adversarial review flagged: if HandleClientMessage returns nil error, the
+// message MUST end up durably cached. The previous Close/send synchronization
+// (separate `closed` chan signal + open data channel) could let a sender
+// commit to the buffer after the writer goroutine had already exited via the
+// closed-signal arm, silently losing audit data.
+//
+// To exercise the race, we use a starting barrier so a wave of senders all
+// hit the channel right when Close runs, maximising the chance that a send
+// commits to the buffer concurrently with Close closing the channel. The
+// test asserts the invariant on every iteration of an inner loop so a single
+// run gives many race attempts; combine with `-race -count=N` for stress.
+func TestRelaySession_NoMessageLossUnderCloseRace(t *testing.T) {
+	const (
+		iterations = 25
+		senders    = 500
+	)
+	for iter := range iterations {
+		t.Run(fmt.Sprintf("iter-%02d", iter), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			relayCfg := &config.RelayConfig{
+				RelayCacheDirectory:  tmpDir,
+				ReconnectAttempts:    0, // skip phase 2; leaves the *.log cache file in place
+				MaxReconnectInterval: 50 * time.Millisecond,
+				ConnectTimeout:       50 * time.Millisecond,
+				UpstreamHost:         "127.0.0.1:1", // unreachable
+			}
+
+			sessionUUID := uuid.New()
+			session, err := NewSession(t.Context(), sessionUUID, createTestAcceptMessage(), relayCfg, nil)
+			if err != nil {
+				t.Fatalf("NewSession: %v", err)
+			}
+
+			var (
+				startBarrier = make(chan struct{})
+				wg           sync.WaitGroup
+				mu           sync.Mutex
+				acked        = make(map[uint32]struct{}, senders)
+			)
+			wg.Add(senders)
+			for i := range senders {
+				go func(i int) {
+					defer wg.Done()
+					payload := make([]byte, 4)
+					binary.BigEndian.PutUint32(payload, uint32(i))
+					msg := &pb.ClientMessage{Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{
+						Delay: &pb.TimeSpec{TvSec: 0, TvNsec: 0},
+						Data:  payload,
+					}}}
+					<-startBarrier
+					if _, err := session.HandleClientMessage(msg); err == nil {
+						mu.Lock()
+						acked[uint32(i)] = struct{}{}
+						mu.Unlock()
+					}
+				}(i)
+			}
+			// Release the senders, then Close almost immediately. This
+			// maximises the chance that some sends are still committing
+			// when Close closes the channel.
+			close(startBarrier)
+			if err := session.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			wg.Wait()
+			waitRelaySession(t, session, 5*time.Second)
+
+			cachePath := filepath.Join(tmpDir, sessionUUID.String()+".log")
+			cached, err := readCachedPayloads(cachePath)
+			if err != nil {
+				t.Fatalf("read cache: %v", err)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for idx := range acked {
+				if _, ok := cached[idx]; !ok {
+					t.Fatalf("data loss: sender %d returned nil error but its payload is absent from cache (ack=%d cached=%d)",
+						idx, len(acked), len(cached))
+				}
+			}
+		})
+	}
+}
+
+// readCachedPayloads opens the relay cache file and returns the set of
+// TtyoutBuf payload sender-indices it contains. Non-Ttyout messages
+// (AcceptMsg from session init) are skipped.
+func readCachedPayloads(path string) (map[uint32]struct{}, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := make(map[uint32]struct{})
+	for {
+		msg, err := readProtoMessage(f)
+		if errors.Is(err, io.EOF) {
+			return out, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		buf := msg.GetTtyoutBuf()
+		if buf == nil {
+			continue
+		}
+		data := buf.GetData()
+		if len(data) != 4 {
+			continue
+		}
+		out[binary.BigEndian.Uint32(data)] = struct{}{}
+	}
 }

--- a/internal/server/api_e2e_test.go
+++ b/internal/server/api_e2e_test.go
@@ -349,7 +349,7 @@ func waitFor(cond func() bool, timeout time.Duration) error {
 
 func apiRequest(t *testing.T, url, token string) *http.Response {
 	t.Helper()
-	req, _ := http.NewRequest("GET", url, nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -125,8 +125,9 @@ func (s *Server) Start() error {
 	plaintextAddr := cfg.Server.ListenAddress
 	tlsAddr := cfg.Server.ListenAddressTLS
 	for _, l := range s.listeners {
-		s.waitGroup.Add(1)
-		go s.acceptLoop(l)
+		// waitGroup.Go (Go 1.25+) atomically pairs Add with the goroutine
+		// launch, eliminating the rare Add/Wait race the old pattern had.
+		s.waitGroup.Go(func() { s.acceptLoop(l) })
 	}
 	if plaintextAddr != "" {
 		slog.Info("Started plaintext listener", "address", plaintextAddr)
@@ -147,8 +148,7 @@ func (s *Server) Start() error {
 
 	// Phase 3: ancillary goroutines under the server's lifecycle so shutdown
 	// cancels them cleanly.
-	s.waitGroup.Add(1)
-	go s.logMetricsPeriodically()
+	s.waitGroup.Go(s.logMetricsPeriodically)
 
 	if cfg.Server.Mode == "relay" {
 		s.waitGroup.Go(func() {
@@ -173,8 +173,8 @@ func (s *Server) closeListeners() {
 }
 
 // acceptLoop continuously accepts new connections on a listener.
+// Launched via waitGroup.Go, which owns the Done call.
 func (s *Server) acceptLoop(listener net.Listener) {
-	defer s.waitGroup.Done()
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -215,6 +215,12 @@ func (s *Server) acceptLoop(listener net.Listener) {
 					"remote_addr", conn.RemoteAddr(),
 					"limit", cap(s.connSem),
 					"failed_connections", metrics.Global.GetFailedConnections())
+				// A TLS peer that hasn't completed the handshake can pin
+				// Close() if we don't bound it: tls.Conn.Close will try to
+				// flush the alert record. SetDeadline forces the close to
+				// fail fast so the rejection path can't be used as a
+				// slowloris against us.
+				_ = conn.SetDeadline(time.Now().Add(time.Second))
 				_ = conn.Close()
 				continue
 			}
@@ -223,20 +229,18 @@ func (s *Server) acceptLoop(listener net.Listener) {
 		slog.Info("Accepted new connection", "remote_addr", conn.RemoteAddr(), "local_addr", conn.LocalAddr(),
 			"total_connections", metrics.Global.GetTotalConnections(), "active_connections", metrics.Global.GetActiveConnections())
 
-		s.waitGroup.Add(1)
-		go func() {
+		s.waitGroup.Go(func() {
 			defer func() {
 				if s.connSem != nil {
 					<-s.connSem
 				}
-				s.waitGroup.Done()
 				metrics.Global.DecrementActiveConnections()
 			}()
 			slog.Debug("Starting connection handler", "remote_addr", conn.RemoteAddr())
 			handler := connection.NewHandlerWithContext(s.ctx, conn, s.config.Load(), s.registry)
 			handler.Handle()
 			slog.Debug("Connection handler finished", "remote_addr", conn.RemoteAddr())
-		}()
+		})
 	}
 }
 
@@ -271,8 +275,14 @@ func (s *Server) Wait(shutdownTimeout time.Duration) {
 	// Stop the management API first so callers see a clean refusal rather than
 	// a stale snapshot of sessions that are about to tear down. http.Server.Shutdown
 	// drains in-flight requests but stops accepting new ones immediately.
+	// Give it at most half of the overall shutdown budget so the protocol
+	// listeners and their handlers still get their fair share.
 	if s.apiServer != nil {
-		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		apiTimeout := 5 * time.Second
+		if shutdownTimeout > 0 && shutdownTimeout/2 < apiTimeout {
+			apiTimeout = shutdownTimeout / 2
+		}
+		shutCtx, cancel := context.WithTimeout(context.Background(), apiTimeout)
 		if err := s.apiServer.Shutdown(shutCtx); err != nil {
 			slog.Error("Management API shutdown error", "error", err)
 		}
@@ -379,9 +389,9 @@ func restartRequiredReloadChange(oldCfg, newCfg *config.Config) string {
 	}
 }
 
-// logMetricsPeriodically logs server metrics every 5 minutes for operational visibility.
+// logMetricsPeriodically logs server metrics every 5 minutes for operational
+// visibility. Launched via waitGroup.Go, which owns the Done call.
 func (s *Server) logMetricsPeriodically() {
-	defer s.waitGroup.Done()
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,12 +11,15 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"math/big"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sudosrv/internal/config"
 	"sudosrv/internal/metrics"
 	"testing"
@@ -75,7 +78,8 @@ func generateSelfSignedCert(t *testing.T) (certPath, keyPath string) {
 }
 
 // shutdown drives the post-signal portion of Server.Wait so tests can run
-// the full lifecycle without going through signal delivery.
+// the full lifecycle without going through signal delivery. Bounds the
+// final waitGroup.Wait so a flaky test cannot hang the runner indefinitely.
 func shutdown(srv *Server) {
 	srv.cancel()
 	if srv.apiServer != nil {
@@ -86,7 +90,16 @@ func shutdown(srv *Server) {
 	for _, l := range srv.listeners {
 		_ = l.Close()
 	}
-	srv.waitGroup.Wait()
+	done := make(chan struct{})
+	go func() { srv.waitGroup.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		// A regression in shutdown wiring would otherwise pin the test
+		// process. Print rather than t.Fatal because shutdown is also
+		// called from t.Cleanup paths where t.Fatal is a no-op.
+		fmt.Fprintln(os.Stderr, "test shutdown timed out waiting for goroutines")
+	}
 }
 
 func newTestServer(t *testing.T, cfg *config.Config) *Server {
@@ -152,7 +165,7 @@ func TestStart_NoListeners(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start: want error, got nil")
 	}
-	if got := err.Error(); !contains(got, "no listeners configured") {
+	if got := err.Error(); !strings.Contains(got,"no listeners configured") {
 		t.Errorf("Start error: got %q, want contains 'no listeners configured'", got)
 	}
 }
@@ -171,7 +184,7 @@ func TestStart_TLSWithoutCertKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start: want error, got nil")
 	}
-	if got := err.Error(); !contains(got, "tls_cert_file") {
+	if got := err.Error(); !strings.Contains(got,"tls_cert_file") {
 		t.Errorf("Start error: got %q, want contains 'tls_cert_file'", got)
 	}
 	if len(srv.listeners) != 0 {
@@ -195,7 +208,7 @@ func TestStart_TLSBadCertPath(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start: want error, got nil")
 	}
-	if got := err.Error(); !contains(got, "TLS key pair") {
+	if got := err.Error(); !strings.Contains(got,"TLS key pair") {
 		t.Errorf("Start error: got %q, want contains 'TLS key pair'", got)
 	}
 }
@@ -233,7 +246,7 @@ func TestStart_APIBindFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start: want error, got nil")
 	}
-	if got := err.Error(); !contains(got, "management API") {
+	if got := err.Error(); !strings.Contains(got,"management API") {
 		t.Errorf("Start error: got %q, want contains 'management API'", got)
 	}
 	if srv.apiServer != nil {
@@ -271,7 +284,7 @@ func TestStart_APITLSFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start: want error, got nil")
 	}
-	if got := err.Error(); !contains(got, "management API") {
+	if got := err.Error(); !strings.Contains(got,"management API") {
 		t.Errorf("Start error: got %q, want contains 'management API'", got)
 	}
 }
@@ -418,7 +431,7 @@ func TestAcceptLoop_RejectsOverCap(t *testing.T) {
 		// Some platforms surface this as a different error (e.g., ECONNRESET);
 		// any non-nil read error is acceptable, just not nil/timeout.
 		var ne net.Error
-		if asNetError(err, &ne) && ne.Timeout() {
+		if errors.As(err, &ne) && ne.Timeout() {
 			t.Errorf("read on rejected connection timed out; expected close")
 		}
 	}
@@ -724,35 +737,6 @@ local_storage:
 }
 
 // --- tiny helpers (kept private to this test file) ---
-
-// contains is a strings.Contains shim; pulling in the strings package just for
-// this would be slightly wasteful given how few callers we have.
-func contains(s, substr string) bool {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
-// asNetError unwraps to net.Error using errors.As semantics without pulling
-// in errors here. Returns false if the conversion fails.
-func asNetError(err error, target *net.Error) bool {
-	for err != nil {
-		if ne, ok := err.(net.Error); ok {
-			*target = ne
-			return true
-		}
-		type wrapper interface{ Unwrap() error }
-		if w, ok := err.(wrapper); ok {
-			err = w.Unwrap()
-			continue
-		}
-		return false
-	}
-	return false
-}
 
 // runtimeYield gives the runtime a brief moment between polls.
 func runtimeYield() {

--- a/internal/sessions/registry.go
+++ b/internal/sessions/registry.go
@@ -18,6 +18,11 @@ import (
 // SessionInfo is the registry record for one active session. Static fields are
 // populated at registration time; live fields are obtained via Provider on
 // demand so the API never returns stale counters.
+//
+// Info is a reference type (map). The registry treats it as read-only after
+// Register; callers MUST NOT mutate the map returned from Get/Snapshot.
+// API handlers that need to expose Info externally should defensive-copy via
+// maps.Clone — see internal/api/server.go:detail.
 type SessionInfo struct {
 	SessionID    string           // sessionUUID.String(); registry key
 	ServerLogID  string           // base64-encoded sudo log_id; populated after session init
@@ -27,7 +32,7 @@ type SessionInfo struct {
 	StartedAt    time.Time        // server-side connection start
 	SubmitTime   time.Time        // AcceptMessage.submit_time
 	ExpectIobufs bool             // whether I/O buffers are expected for this session
-	Info         map[string]any   // flattened AcceptMessage.InfoMsgs
+	Info         map[string]any   // flattened AcceptMessage.InfoMsgs; treat as read-only post-Register
 	Provider     MetadataProvider // optional accessor for live counters
 }
 

--- a/internal/sessions/registry.go
+++ b/internal/sessions/registry.go
@@ -84,9 +84,17 @@ func NewRegistry() *Registry {
 // the same SessionID. A nil receiver is a no-op so callers that may not have a
 // registry (e.g., unit tests) can call this unconditionally.
 //
-// If an existing entry under the same SessionID had a different ServerLogID,
-// the old index entry is cleaned up so the registry never serves a stale
-// logID → sessionID mapping.
+// Two cases need careful index hygiene:
+//
+//  1. Re-register under the same SessionID with a different ServerLogID:
+//     drop the old logID → SessionID mapping so it can't outlive its owner.
+//  2. Register under a NEW SessionID with the same ServerLogID as an existing
+//     entry (e.g., a restart/reconnect overlap where the old connection is
+//     still finishing teardown): the newer entry takes ownership of the
+//     logID index. The older SessionID is still reachable via its primary
+//     key, but Get(logID) returns the newer record. This matches operator
+//     intent — when two sessions share a log_id during an overlap, the
+//     active recovery is the one worth surfacing.
 func (r *Registry) Register(info SessionInfo) {
 	if r == nil || info.SessionID == "" {
 		return
@@ -104,13 +112,22 @@ func (r *Registry) Register(info SessionInfo) {
 
 // Deregister removes the session with the given ID. Missing IDs are silently
 // ignored. A nil receiver is a no-op.
+//
+// The secondary-index delete is OWNERSHIP-AWARE: we only drop
+// byLogID[prev.ServerLogID] when it still points at the SessionID being
+// removed. If a newer session has since claimed the same ServerLogID
+// (restart/reconnect overlap), removing the old session must not clobber
+// the newer one's lookup — that would 404 a recovery session that an
+// operator is actively trying to inspect.
 func (r *Registry) Deregister(sessionID string) {
 	if r == nil || sessionID == "" {
 		return
 	}
 	r.mu.Lock()
 	if prev, ok := r.sessions[sessionID]; ok && prev.ServerLogID != "" {
-		delete(r.byLogID, prev.ServerLogID)
+		if owner, ok := r.byLogID[prev.ServerLogID]; ok && owner == sessionID {
+			delete(r.byLogID, prev.ServerLogID)
+		}
 	}
 	delete(r.sessions, sessionID)
 	r.mu.Unlock()

--- a/internal/sessions/registry.go
+++ b/internal/sessions/registry.go
@@ -57,25 +57,43 @@ type LiveStats struct {
 // The static fields of SessionInfo are set once at Register time; live
 // counters are read through the MetadataProvider hook, which uses its own
 // synchronization (typically sync/atomic) on the underlying session.
+//
+// byLogID is a secondary index mapping ServerLogID → SessionID so Get() can
+// answer either-form lookups in O(1) instead of a linear scan that an
+// authenticated client could trivially weaponize by polling random IDs.
 type Registry struct {
 	mu       sync.RWMutex
 	sessions map[string]SessionInfo
+	byLogID  map[string]string
 }
 
 // NewRegistry returns an empty registry ready for use.
 func NewRegistry() *Registry {
-	return &Registry{sessions: make(map[string]SessionInfo)}
+	return &Registry{
+		sessions: make(map[string]SessionInfo),
+		byLogID:  make(map[string]string),
+	}
 }
 
 // Register adds a session to the registry, replacing any existing entry with
 // the same SessionID. A nil receiver is a no-op so callers that may not have a
 // registry (e.g., unit tests) can call this unconditionally.
+//
+// If an existing entry under the same SessionID had a different ServerLogID,
+// the old index entry is cleaned up so the registry never serves a stale
+// logID → sessionID mapping.
 func (r *Registry) Register(info SessionInfo) {
 	if r == nil || info.SessionID == "" {
 		return
 	}
 	r.mu.Lock()
+	if prev, ok := r.sessions[info.SessionID]; ok && prev.ServerLogID != "" && prev.ServerLogID != info.ServerLogID {
+		delete(r.byLogID, prev.ServerLogID)
+	}
 	r.sessions[info.SessionID] = info
+	if info.ServerLogID != "" {
+		r.byLogID[info.ServerLogID] = info.SessionID
+	}
 	r.mu.Unlock()
 }
 
@@ -86,13 +104,16 @@ func (r *Registry) Deregister(sessionID string) {
 		return
 	}
 	r.mu.Lock()
+	if prev, ok := r.sessions[sessionID]; ok && prev.ServerLogID != "" {
+		delete(r.byLogID, prev.ServerLogID)
+	}
 	delete(r.sessions, sessionID)
 	r.mu.Unlock()
 }
 
 // Get returns a copy of the registered session matching id. The lookup tries
-// the SessionID (UUID form) first, then falls back to a linear scan for a
-// matching ServerLogID so callers can paste either form.
+// the SessionID (UUID form) first, then the ServerLogID secondary index, so
+// callers can paste either form and pay only O(1) work.
 func (r *Registry) Get(id string) (SessionInfo, bool) {
 	if r == nil || id == "" {
 		return SessionInfo{}, false
@@ -102,8 +123,8 @@ func (r *Registry) Get(id string) (SessionInfo, bool) {
 	if s, ok := r.sessions[id]; ok {
 		return s, true
 	}
-	for _, s := range r.sessions {
-		if s.ServerLogID != "" && s.ServerLogID == id {
+	if sid, ok := r.byLogID[id]; ok {
+		if s, ok := r.sessions[sid]; ok {
 			return s, true
 		}
 	}

--- a/internal/sessions/registry_test.go
+++ b/internal/sessions/registry_test.go
@@ -258,6 +258,53 @@ func TestRegistry_GetByLogIDIsO1(t *testing.T) {
 	}
 }
 
+// TestRegistry_DuplicateLogIDOverlap pins the ownership-aware Deregister
+// behavior Codex's second adversarial review flagged. Two sessions can
+// temporarily share a ServerLogID during a restart/reconnect overlap; the
+// newer session takes ownership of the secondary index. Deregistering the
+// OLD session must not delete the newer session's lookup — that would
+// 404 a recovery session in the management API at exactly the moment
+// operators want to inspect it.
+func TestRegistry_DuplicateLogIDOverlap(t *testing.T) {
+	r := NewRegistry()
+	idA := uuid.New()
+	idB := uuid.New()
+	const sharedLogID = "shared-log-id"
+
+	r.Register(SessionInfo{
+		SessionID:   idA.String(),
+		SessionUUID: idA,
+		ServerLogID: sharedLogID,
+		StartedAt:   time.Unix(1, 0),
+	})
+	r.Register(SessionInfo{
+		SessionID:   idB.String(),
+		SessionUUID: idB,
+		ServerLogID: sharedLogID, // overlap: newer entry claims the index
+		StartedAt:   time.Unix(2, 0),
+	})
+
+	// Lookup by shared ServerLogID returns the newer session.
+	if got, ok := r.Get(sharedLogID); !ok || got.SessionID != idB.String() {
+		t.Fatalf("after overlap: Get(%q) = (%+v, %v), want session B", sharedLogID, got, ok)
+	}
+
+	// Deregistering the OLDER session must NOT remove B's lookup.
+	r.Deregister(idA.String())
+	if got, ok := r.Get(sharedLogID); !ok || got.SessionID != idB.String() {
+		t.Fatalf("after Deregister(A): Get(%q) = (%+v, %v); B must still be reachable by log_id", sharedLogID, got, ok)
+	}
+	if _, ok := r.Get(idA.String()); ok {
+		t.Error("Deregister(A) should remove A's primary key entry")
+	}
+
+	// Deregistering B (the actual owner) finally clears the secondary index.
+	r.Deregister(idB.String())
+	if _, ok := r.Get(sharedLogID); ok {
+		t.Errorf("after Deregister(B): Get(%q) should miss", sharedLogID)
+	}
+}
+
 // Sanity: ensure %v formatting of a SessionInfo doesn't panic, useful when
 // tests include diagnostic output.
 func TestSessionInfo_FormatStable(t *testing.T) {

--- a/internal/sessions/registry_test.go
+++ b/internal/sessions/registry_test.go
@@ -218,6 +218,46 @@ func BenchmarkRegistry_Snapshot(b *testing.B) {
 	}
 }
 
+// TestRegistry_GetByLogIDIsO1 pins the secondary-index behavior: a lookup by
+// ServerLogID must succeed without falling back to a linear scan, and the
+// index must stay coherent across replacement and deregistration so an old
+// logID cannot resolve to a session that has since taken its place.
+func TestRegistry_GetByLogIDIsO1(t *testing.T) {
+	r := NewRegistry()
+	id := uuid.New()
+	r.Register(SessionInfo{
+		SessionID:   id.String(),
+		SessionUUID: id,
+		ServerLogID: "logA",
+		StartedAt:   time.Unix(1, 0),
+	})
+
+	if got, ok := r.Get("logA"); !ok || got.SessionID != id.String() {
+		t.Fatalf("Get by ServerLogID: got=%+v ok=%v", got, ok)
+	}
+
+	// Replacement under the same SessionID with a new ServerLogID must drop
+	// the stale logID → SessionID mapping.
+	r.Register(SessionInfo{
+		SessionID:   id.String(),
+		SessionUUID: id,
+		ServerLogID: "logB",
+		StartedAt:   time.Unix(2, 0),
+	})
+	if _, ok := r.Get("logA"); ok {
+		t.Error("stale logA lookup should miss after re-registration with logB")
+	}
+	if got, ok := r.Get("logB"); !ok || got.SessionID != id.String() {
+		t.Errorf("Get by new logB failed: got=%+v ok=%v", got, ok)
+	}
+
+	// Deregister must drop the secondary index entry too.
+	r.Deregister(id.String())
+	if _, ok := r.Get("logB"); ok {
+		t.Error("logB lookup should miss after Deregister")
+	}
+}
+
 // Sanity: ensure %v formatting of a SessionInfo doesn't panic, useful when
 // tests include diagnostic output.
 func TestSessionInfo_FormatStable(t *testing.T) {

--- a/internal/storage/filter.go
+++ b/internal/storage/filter.go
@@ -12,10 +12,22 @@ import (
 // 128 bytes fits a long multi-byte prompt plus ANSI escape sequences.
 const tailWindowSize = 128
 
+// csiPattern matches a single ANSI/CSI escape sequence. Terminals often emit
+// these when redrawing a prompt line ("Password\x1b[K:" for clear-to-EOL),
+// which would otherwise prevent the password regex from matching and let the
+// secret through to disk in plaintext. Stripping CSI from the search window
+// (not from the on-the-wire data) keeps prompt detection robust to redraw.
+var csiPattern = regexp.MustCompile("\x1b\\[[0-9;?]*[a-zA-Z@]")
+
 // PasswordFilter provides regex-based password prompt detection and input masking.
 // It maintains a sliding window of recent tty output so prompts that straddle
 // message boundaries still trigger filtering. All methods are safe for
 // concurrent use.
+//
+// A PasswordFilter must NOT be reused across sessions without calling Reset() —
+// a half-detected prompt from a previous session would carry isFiltering=true
+// into the next session and mask its first input line. The Session type creates
+// a fresh filter per session, so this is enforced by construction.
 type PasswordFilter struct {
 	mu          sync.Mutex
 	patterns    []*regexp.Regexp
@@ -33,10 +45,12 @@ type PasswordFilter struct {
 //     "пароль" (ru), "密码"/"パスワード" (CJK)
 func NewPasswordFilter() *PasswordFilter {
 	filter := &PasswordFilter{}
+	// The "for X" sub-pattern matches the canonical sudo prompt
+	// ("[sudo] password for alice:") and ssh's "Enter passphrase for key X:".
 	defaults := []string{
-		`(?i)pass(word|phrase|wd)\s*[:：]`,
+		`(?i)pass(word|phrase|wd)(\s+for\s+\S+)?\s*[:：]`,
 		`(?i)\bPIN\b\s*[:：]`,
-		`(?i)\bpasswort\b\s*[:：]`,
+		`(?i)\bpasswort\b(\s+f[üu]r\s+\S+)?\s*[:：]`,
 		`(?i)contrase[ñn]a\s*[:：]`,
 		`(?i)mot de passe\s*[:：]`,
 		`(?i)\bsenha\b\s*[:：]`,
@@ -65,21 +79,27 @@ func (f *PasswordFilter) AddPattern(pattern string) error {
 // CheckOutput examines terminal output for password prompts. A rolling tail
 // from prior calls is prepended so a prompt split across two I/O buffers (for
 // example "Passw" arriving in one message and "ord:" in the next) still
-// matches. Call on TTYOUT data.
+// matches. CSI escape sequences (cursor movement, clear-to-EOL, color codes
+// commonly emitted by prompt redraw) are stripped from the search window
+// before regex matching. Call on TTYOUT data.
 func (f *PasswordFilter) CheckOutput(data []byte) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	// Build the search window: previous tail + current data.
-	window := data
+	// Build the raw window: previous tail + current data.
+	raw := data
 	if len(f.tail) > 0 {
-		window = make([]byte, 0, len(f.tail)+len(data))
-		window = append(window, f.tail...)
-		window = append(window, data...)
+		raw = make([]byte, 0, len(f.tail)+len(data))
+		raw = append(raw, f.tail...)
+		raw = append(raw, data...)
 	}
 
+	// Match against an escape-stripped copy. Keep the raw bytes for the tail
+	// so multi-byte UTF-8 prompts that straddle the boundary still match next
+	// call after stripping.
+	search := csiPattern.ReplaceAll(raw, nil)
 	for _, pattern := range f.patterns {
-		if pattern.Match(window) {
+		if pattern.Match(search) {
 			f.isFiltering = true
 			// Clear the tail on a match so the next prompt doesn't keep firing
 			// on the stale window; input will flip filtering off on newline.
@@ -88,11 +108,11 @@ func (f *PasswordFilter) CheckOutput(data []byte) {
 		}
 	}
 
-	// Preserve the last tailWindowSize bytes for the next call.
-	if len(window) > tailWindowSize {
-		window = window[len(window)-tailWindowSize:]
+	// Preserve the last tailWindowSize bytes of raw data for the next call.
+	if len(raw) > tailWindowSize {
+		raw = raw[len(raw)-tailWindowSize:]
 	}
-	f.tail = append(f.tail[:0], window...)
+	f.tail = append(f.tail[:0], raw...)
 }
 
 // FilterInput masks input bytes while filtering is active. A carriage return

--- a/internal/storage/filter_test.go
+++ b/internal/storage/filter_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Filename: internal/storage/filter_test.go
+package storage
+
+import "testing"
+
+// TestPasswordFilter_DetectsPrompts covers the baseline patterns: ASCII,
+// non-ASCII (German), and the standard sudo prompt shape.
+func TestPasswordFilter_DetectsPrompts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		prompt string
+	}{
+		{"english password", "Password: "},
+		{"passwd colon", "passwd: "},
+		{"passphrase", "Enter passphrase:"},
+		{"sudo style", "[sudo] password for alice: "},
+		{"german", "Passwort: "},
+		{"fullwidth colon", "Password："},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := NewPasswordFilter()
+			f.CheckOutput([]byte(tc.prompt))
+			if !f.IsFiltering() {
+				t.Fatalf("prompt %q did not trigger filtering", tc.prompt)
+			}
+		})
+	}
+}
+
+// TestPasswordFilter_StripsCSI verifies the CSI bypass fix: terminal redraw
+// often interleaves cursor/color codes between "Password" and ":", which
+// previously prevented the regex from matching and let the secret through.
+func TestPasswordFilter_StripsCSI(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		prompt string
+	}{
+		{"clear-to-EOL between word and colon", "Password\x1b[K: "},
+		{"color reset between word and colon", "Password\x1b[0m: "},
+		{"cursor move embedded", "Pass\x1b[1;5Hword: "},
+		{"multiple CSI sequences", "\x1b[1mPassword\x1b[0m\x1b[K: "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := NewPasswordFilter()
+			f.CheckOutput([]byte(tc.prompt))
+			if !f.IsFiltering() {
+				t.Fatalf("CSI-embedded prompt %q did not trigger filtering", tc.prompt)
+			}
+		})
+	}
+}
+
+// TestPasswordFilter_SplitAcrossCalls verifies the rolling-window tail
+// preserves enough context to match a prompt that arrives in two pieces.
+func TestPasswordFilter_SplitAcrossCalls(t *testing.T) {
+	t.Parallel()
+	f := NewPasswordFilter()
+	f.CheckOutput([]byte("Passw"))
+	if f.IsFiltering() {
+		t.Fatal("partial prompt should not trigger filtering yet")
+	}
+	f.CheckOutput([]byte("ord: "))
+	if !f.IsFiltering() {
+		t.Fatal("completed prompt across calls did not trigger filtering")
+	}
+}
+
+// TestPasswordFilter_MasksInputUntilNewline verifies FilterInput masks bytes
+// while filtering is active and disables itself on newline.
+func TestPasswordFilter_MasksInputUntilNewline(t *testing.T) {
+	t.Parallel()
+	f := NewPasswordFilter()
+	f.CheckOutput([]byte("Password: "))
+	if !f.IsFiltering() {
+		t.Fatal("setup failed: filter did not engage")
+	}
+	got := f.FilterInput([]byte("secret\n"))
+	want := "******\n"
+	if string(got) != want {
+		t.Errorf("FilterInput(secret\\n) = %q, want %q", got, want)
+	}
+	if f.IsFiltering() {
+		t.Error("filter should be disabled after newline")
+	}
+}
+
+// TestPasswordFilter_NonFilteringPassthrough verifies non-prompt output does
+// not trigger filtering and input passes through unchanged.
+func TestPasswordFilter_NonFilteringPassthrough(t *testing.T) {
+	t.Parallel()
+	f := NewPasswordFilter()
+	f.CheckOutput([]byte("hello world\n"))
+	if f.IsFiltering() {
+		t.Error("non-prompt output should not trigger filtering")
+	}
+	got := f.FilterInput([]byte("hello"))
+	if string(got) != "hello" {
+		t.Errorf("FilterInput should passthrough when not filtering, got %q", got)
+	}
+}
+
+// TestPasswordFilter_Reset clears filtering state for session reuse safety.
+func TestPasswordFilter_Reset(t *testing.T) {
+	t.Parallel()
+	f := NewPasswordFilter()
+	f.CheckOutput([]byte("Password: "))
+	if !f.IsFiltering() {
+		t.Fatal("setup failed")
+	}
+	f.Reset()
+	if f.IsFiltering() {
+		t.Error("Reset should clear isFiltering")
+	}
+}

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Filename: internal/storage/session.go
+
+//go:build unix
+
 package storage
 
 import (
@@ -16,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sudosrv/internal/config"
 	"sudosrv/internal/protocol"
@@ -35,6 +39,14 @@ import (
 const commitPointInterval = 10 * time.Second
 
 // Session handles saving I/O logs for one session to the local filesystem.
+//
+// Lock ordering (must be observed by any code added later):
+//
+//	fileMux  → passwordFilter.mu
+//
+// HandleClientMessage acquires fileMux and may then call into passwordFilter
+// methods (CheckOutput/FilterInput) which take passwordFilter.mu internally.
+// Acquiring locks in the reverse order will deadlock.
 type Session struct {
 	logID           string
 	sessionUUID     uuid.UUID
@@ -51,13 +63,19 @@ type Session struct {
 	fileMux         sync.Mutex
 	closeOnce       sync.Once
 	isInitialized   bool
-	// Live stats exposed to the management API. Updated with atomic ops so
-	// the API's read path never blocks on fileMux held by the write path.
-	// Writes themselves still happen while fileMux is held by HandleClientMessage.
+	// Live stats exposed to the management API. Each counter is an independent
+	// atomic, so a reader may observe an incoherent triple (e.g. msgCount
+	// incremented but bytesReceived not yet, or lastActivity stale by one
+	// message). Eventual consistency is acceptable for an admin UI; do not
+	// rely on these for correctness checks.
 	msgCount      atomic.Int64
 	bytesReceived atomic.Int64
 	lastActivity  atomic.Pointer[time.Time]
 }
+
+// Compile-time check that Session satisfies the sessions.MetadataProvider
+// contract consumed by the management API.
+var _ sessions.MetadataProvider = (*Session)(nil)
 
 // IO event types for the timing file, matching native sudo implementation.
 const (
@@ -228,11 +246,16 @@ type EventSession struct {
 	logJSONPath string
 	logMeta     map[string]any
 	closeOnce   sync.Once
-	// Live stats exposed to the management API.
+	// Live stats exposed to the management API. Same eventual-consistency
+	// contract as Session: each counter is an independent atomic and an API
+	// reader may observe an incoherent triple. Do not use for correctness.
 	msgCount      atomic.Int64
 	bytesReceived atomic.Int64
 	lastActivity  atomic.Pointer[time.Time]
 }
+
+// Compile-time check that EventSession satisfies sessions.MetadataProvider.
+var _ sessions.MetadataProvider = (*EventSession)(nil)
 
 // NewEventSession creates a local metadata-only session for an accepted command
 // where ExpectIobufs is false.
@@ -455,7 +478,7 @@ func buildSessionPath(sessionUUID uuid.UUID, cfg *config.LocalStorageConfig, acc
 		case *pb.InfoMessage_Strval:
 			infoMap[key] = v.Strval
 		case *pb.InfoMessage_Numval:
-			infoMap[key] = fmt.Sprintf("%d", v.Numval)
+			infoMap[key] = strconv.FormatInt(v.Numval, 10)
 		}
 	}
 
@@ -469,7 +492,7 @@ func buildSessionPath(sessionUUID uuid.UUID, cfg *config.LocalStorageConfig, acc
 		return "", fmt.Errorf("failed to generate random string: %w", err)
 	}
 	now := time.Now()
-	epochStr := fmt.Sprintf("%d", now.Unix())
+	epochStr := strconv.FormatInt(now.Unix(), 10)
 
 	// Replacer for sudoers-style escape sequences.
 	// User-controlled values are sanitized to strip "/" characters,
@@ -543,6 +566,24 @@ func getMutexForDir(dir string) *sync.Mutex {
 	return mutex
 }
 
+// readLogJSON opens, decodes, and closes a log.json file. Keeping the file
+// handle scoped to this helper prevents the double-close hazard that arose
+// when the decode-then-close sequence was inlined into a restart path with
+// multiple downstream error returns.
+func readLogJSON(path string) (map[string]any, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log.json for restart: %w", err)
+	}
+	defer f.Close()
+
+	logMeta := make(map[string]any)
+	if err := json.NewDecoder(f).Decode(&logMeta); err != nil {
+		return nil, fmt.Errorf("failed to read existing log.json: %w", err)
+	}
+	return logMeta, nil
+}
+
 // getNextSeq generates a sudo-compatible 6-character sequence number with file locking.
 func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) {
 	mutex := getMutexForDir(baseDir)
@@ -561,13 +602,15 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("could not open sequence file %s: %w", seqFile, err)
 	}
+	// f.Close releases the flock implicitly on Linux/BSD — no explicit
+	// LOCK_UN defer needed. (Pairing one with the file-Close defer would
+	// run LOCK_UN first under LIFO ordering, which is harmless today but a
+	// footgun if the close path is ever wrapped or replaced.)
 	defer f.Close()
 
-	// Apply file lock for additional safety
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
 		return "", fmt.Errorf("could not lock sequence file: %w", err)
 	}
-	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 
 	// Get file info to check size
 	stat, err := f.Stat()
@@ -585,7 +628,15 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 		currentSeq = binary.BigEndian.Uint32(data)
 	}
 
-	// Increment and wrap if necessary (sudo uses a base36 encoding)
+	// Sequence numbers are encoded as 6-char base36 strings; 36^6 = 2,176,782,336
+	// is the maximum representable. Beyond that we'd silently truncate via the
+	// modulo loop and collide with earlier sequences, corrupting session
+	// uniqueness. Fail loudly instead.
+	const maxSeq uint32 = 36 * 36 * 36 * 36 * 36 * 36
+	if currentSeq >= maxSeq-1 {
+		return "", fmt.Errorf("sequence space exhausted at %d (max %d); rotate %s to recover",
+			currentSeq, maxSeq-1, seqFile)
+	}
 	nextSeq := currentSeq + 1
 
 	// Write the new sequence number back to the file atomically
@@ -721,7 +772,7 @@ func (s *Session) initialize(acceptMsg *pb.AcceptMessage) (retErr error) {
 			value = v.Strval
 			s.logMeta[key] = v.Strval
 		case *pb.InfoMessage_Numval:
-			value = fmt.Sprintf("%d", v.Numval)
+			value = strconv.FormatInt(v.Numval, 10)
 			s.logMeta[key] = v.Numval
 		case *pb.InfoMessage_Strlistval:
 			value = strings.Join(v.Strlistval.Strings, " ")
@@ -907,12 +958,12 @@ func (s *Session) writeIoEntry(streamName string, delay *pb.TimeSpec, data []byt
 		}
 	}
 
-	// Write data - use gzip writer if compression is enabled, otherwise write directly
-	var writer io.Writer
-	if gzWriter, compressed := s.gzipWriters[streamName]; compressed {
+	// Write data - use gzip writer if compression is enabled, otherwise write directly.
+	// One map lookup serves both the choice of writer and the post-write Flush call.
+	gzWriter, compressed := s.gzipWriters[streamName]
+	var writer io.Writer = s.files[streamName]
+	if compressed {
 		writer = gzWriter
-	} else {
-		writer = s.files[streamName]
 	}
 
 	if _, err := writer.Write(dataToWrite); err != nil {
@@ -920,7 +971,7 @@ func (s *Session) writeIoEntry(streamName string, delay *pb.TimeSpec, data []byt
 	}
 
 	// Flush gzip writer if using compression (equivalent to sudo's Z_SYNC_FLUSH)
-	if gzWriter, compressed := s.gzipWriters[streamName]; compressed {
+	if compressed {
 		if err := gzWriter.Flush(); err != nil {
 			return nil, fmt.Errorf("failed to flush gzip writer for %s: %w", streamName, err)
 		}
@@ -1159,20 +1210,14 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 
 	// Read existing log.json. O_NOFOLLOW guards against symlink swap between
 	// session finalize and restart; the subsequent atomic rewrite uses
-	// writeFileAtomic.
+	// writeFileAtomic. Decoded in a helper so the file handle is scoped
+	// strictly to the decode and cannot leak into later error paths.
 	logJSONPath := filepath.Join(sessionDir, "log.json")
-	logJSONFile, err := os.OpenFile(logJSONPath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	logMeta, err := readLogJSON(logJSONPath)
 	if err != nil {
 		timingFile.Close()
-		return nil, fmt.Errorf("failed to open log.json for restart: %w", err)
+		return nil, err
 	}
-	logMeta := make(map[string]any)
-	if err := json.NewDecoder(logJSONFile).Decode(&logMeta); err != nil {
-		logJSONFile.Close()
-		timingFile.Close()
-		return nil, fmt.Errorf("failed to read existing log.json: %w", err)
-	}
-	logJSONFile.Close()
 
 	// Open existing I/O stream files in append mode.
 	// stdin/ttyin may not exist (on-demand creation), so only open files that are present.
@@ -1189,7 +1234,6 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 				openFile.Close()
 			}
 			timingFile.Close()
-			logJSONFile.Close()
 			return nil, fmt.Errorf("failed to open stream file %s for restart: %w", streamName, err)
 		}
 		files[streamName] = f

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -343,12 +343,7 @@ func (s *EventSession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMes
 		if st := event.AcceptMsg.GetSubmitTime(); st != nil {
 			entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 		}
-		for k, v := range protocol.InfoMsgsToMap(event.AcceptMsg.GetInfoMsgs()) {
-			if _, exists := entry[k]; exists {
-				continue
-			}
-			entry[k] = v
-		}
+		mergePreservingExisting(entry, protocol.InfoMsgsToMap(event.AcceptMsg.GetInfoMsgs()))
 		subCmds, _ := s.logMeta["sub_commands"].([]any)
 		subCmds = append(subCmds, entry)
 		s.logMeta["sub_commands"] = subCmds
@@ -361,12 +356,7 @@ func (s *EventSession) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMes
 		if st := event.RejectMsg.GetSubmitTime(); st != nil {
 			entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 		}
-		for k, v := range protocol.InfoMsgsToMap(event.RejectMsg.GetInfoMsgs()) {
-			if _, exists := entry[k]; exists {
-				continue
-			}
-			entry[k] = v
-		}
+		mergePreservingExisting(entry, protocol.InfoMsgsToMap(event.RejectMsg.GetInfoMsgs()))
 		subCmds, _ := s.logMeta["sub_commands"].([]any)
 		subCmds = append(subCmds, entry)
 		s.logMeta["sub_commands"] = subCmds
@@ -564,6 +554,19 @@ func getMutexForDir(dir string) *sync.Mutex {
 	mutex := &sync.Mutex{}
 	seqMutexMap[dir] = mutex
 	return mutex
+}
+
+// mergePreservingExisting copies keys from src into dst that are not already
+// present in dst. Used wherever client-supplied InfoMsgs are merged into a
+// sub-command event entry — the authoritative fields (event_type, reason,
+// submit_time) must never be clobbered by a client-controlled key collision.
+func mergePreservingExisting(dst, src map[string]any) {
+	for k, v := range src {
+		if _, exists := dst[k]; exists {
+			continue
+		}
+		dst[k] = v
+	}
 }
 
 // readLogJSON opens, decodes, and closes a log.json file. Keeping the file
@@ -1075,14 +1078,7 @@ func (s *Session) handleSubCommandAccept(acceptMsg *pb.AcceptMessage) (*pb.Serve
 		entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 	}
 
-	// Merge client-supplied info messages, but never let them clobber the
-	// authoritative fields already set on entry.
-	for k, v := range protocol.InfoMsgsToMap(acceptMsg.GetInfoMsgs()) {
-		if _, exists := entry[k]; exists {
-			continue
-		}
-		entry[k] = v
-	}
+	mergePreservingExisting(entry, protocol.InfoMsgsToMap(acceptMsg.GetInfoMsgs()))
 
 	subCmds, _ := s.logMeta["sub_commands"].([]any)
 	subCmds = append(subCmds, entry)
@@ -1107,14 +1103,7 @@ func (s *Session) handleSubCommandReject(rejectMsg *pb.RejectMessage) (*pb.Serve
 		entry["submit_time"] = time.Unix(st.TvSec, int64(st.TvNsec)).UTC().Format(time.RFC3339Nano)
 	}
 
-	// Merge client-supplied info messages, but never let them clobber the
-	// authoritative fields already set on entry.
-	for k, v := range protocol.InfoMsgsToMap(rejectMsg.GetInfoMsgs()) {
-		if _, exists := entry[k]; exists {
-			continue
-		}
-		entry[k] = v
-	}
+	mergePreservingExisting(entry, protocol.InfoMsgsToMap(rejectMsg.GetInfoMsgs()))
 
 	subCmds, _ := s.logMeta["sub_commands"].([]any)
 	subCmds = append(subCmds, entry)

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -109,8 +109,12 @@ func TestStorageSession(t *testing.T) {
 		if logMeta["submituser"] != "testuser" {
 			t.Errorf("log.json: expected submituser 'testuser', got '%v'", logMeta["submituser"])
 		}
-		if logMeta["exit_value"].(float64) != 0 {
-			t.Errorf("log.json: expected exit_value 0, got '%v'", logMeta["exit_value"])
+		exitVal, ok := logMeta["exit_value"].(float64)
+		if !ok {
+			t.Fatalf("log.json: missing or non-float64 exit_value, got %T %v", logMeta["exit_value"], logMeta["exit_value"])
+		}
+		if exitVal != 0 {
+			t.Errorf("log.json: expected exit_value 0, got '%v'", exitVal)
 		}
 		if logMeta["runcwd"] != "/home/testuser" {
 			t.Errorf("log.json: expected runcwd '/home/testuser', got '%v'", logMeta["runcwd"])
@@ -659,7 +663,10 @@ func TestStorageSession(t *testing.T) {
 		if !ok || len(subCmds) != 1 {
 			t.Fatalf("Expected 1 sub_command, got %v", logMeta["sub_commands"])
 		}
-		subCmd := subCmds[0].(map[string]any)
+		subCmd, ok := subCmds[0].(map[string]any)
+		if !ok {
+			t.Fatalf("sub_command 0: expected map[string]any, got %T", subCmds[0])
+		}
 		if subCmd["event_type"] != "accept" {
 			t.Errorf("Expected event_type 'accept', got '%v'", subCmd["event_type"])
 		}
@@ -726,7 +733,10 @@ func TestStorageSession(t *testing.T) {
 		if !ok || len(subCmds) != 1 {
 			t.Fatalf("Expected 1 sub_command, got %v", logMeta["sub_commands"])
 		}
-		subCmd := subCmds[0].(map[string]any)
+		subCmd, ok := subCmds[0].(map[string]any)
+		if !ok {
+			t.Fatalf("sub_command 0: expected map[string]any, got %T", subCmds[0])
+		}
 		if subCmd["event_type"] != "reject" {
 			t.Errorf("Expected event_type 'reject', got '%v'", subCmd["event_type"])
 		}


### PR DESCRIPTION
## Summary
8 commits across 6 subsystems, prompted by an initial multi-agent review of the codebase and two follow-up adversarial passes by Codex. Every commit is independently reverable; full test suite (`go test -race ./...`) passes after each one.

The two highest-value fixes — caught by Codex's adversarial passes after the initial round was already "done" — are:

- **`c79ceba`** Relay `Close` vs in-flight `HandleClientMessage` race: a sender could commit to the channel after the writer goroutine had exited, silently dropping audit data. Fixed with `sync.RWMutex` ownership; regression test reproduces the loss on pre-fix code.
- **`c9691c3`** Sessions registry secondary-index ownership: deregistering an old session under a restart/reconnect overlap was clobbering the newer session's `server_log_id` lookup, 404'ing the recovery session in the management API.

## Commit-by-commit

| Commit | Subsystem | Headline |
|---|---|---|
| `64551ad` | config | Fail-fast on missing config, AuthTokenFile perm validation, dir-exec-bit check, structured slog, partial-YAML defaults pinned |
| `1d78493` | storage | Password-filter CSI bypass + sudo-prompt pattern, restart double-close, base36 seq exhaustion detection, build constraint, lock-ordering docs |
| `16b9d46` | relay | Cache mode 0600/0700, `time.NewTimer` instead of leaking `time.After`, startup splay, orphan `IsNotExist`→Debug, mock FD-leak fix |
| `161343e` | server/protocol | TLS rejection deadline, watcher-goroutine skip when ctx.Done()==nil, API shutdown timeout derivation, stdlib `strings.Contains`/`errors.As`, `waitGroup.Go` consistency |
| `ddb7c2b` | api | http.Server timeouts + MaxBytesReader, SHA-256 + constant-time token compare, factored TLS, Cache-Control/nosniff, `maps.Clone` on Info, O(1) ServerLogID lookup |
| `ae9dd6c` | cross-cutting | Metrics torn-time fix, `mergePreservingExisting` helper, `t.Context()` migration |
| `c79ceba` | relay | **Close/send synchronization race fix** + regression test |
| `c9691c3` | sessions | **Ownership-aware Deregister** + overlap regression test |

## Stats
\`19 files changed, 1063 insertions(+), 280 deletions(-)\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test -race ./...\` passes (run after every commit)
- [x] New regression tests verified to fail against the corresponding pre-fix code (stashed-fix run)
- [ ] Manual smoke: run \`sudosrv -config config.yaml -dry-run\` to confirm the stricter LoadConfig path
- [ ] Manual smoke: hit the management API endpoint with a token file at 0644 and confirm startup is now refused