### PR TITLE
Modernize Go idioms + wire up golangci-lint & govulncheck in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,4 @@
-name: Makefile CI
+name: CI
 
 on:
   push:
@@ -25,3 +25,33 @@ jobs:
 
     - name: Run tests
       run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v7
+      with:
+        version: v2.12.2
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: govulncheck
+      uses: golang/govulncheck-action@v1
+      with:
+        go-version-file: go.mod

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,73 @@
+version: "2"
+
+run:
+  timeout: 5m
+  go: "1.26"
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - copyloopvar
+    - errorlint
+    - gosec
+    - intrange
+    - modernize
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - os.Remove
+        - (*sudosrv/internal/protocol.Processor).Close
+    gosec:
+      excludes:
+        # G104 — covered by errcheck
+        - G104
+        # G115 — int→uint32/int32 conversions are length-prefix and timestamp
+        # encodings bounded by upstream protocol/syscall semantics.
+        - G115
+        # G304 — file paths are derived from config-driven sudoers escape
+        # sequences with explicit sanitisation (containsDotDot, sanitizePathComponent).
+        - G304
+        # G302 — timing files are deliberately written 0440 (read-only after
+        # session close) to match C sudo_logsrvd behaviour for sudoreplay.
+        - G302
+        # G402 — TLS InsecureSkipVerify is a config-controlled toggle for
+        # operators testing relay against self-signed upstreams.
+        - G402
+        # G404 — math/rand/v2 is used only for jitter, never security.
+        - G404
+    staticcheck:
+      checks:
+        - all
+        # Protocol-event constants (IO_EVENT_*) intentionally match the
+        # wire-protocol naming so a reader of the protobuf spec finds them
+        # under the same identifiers.
+        - -ST1003
+        # Package/exported-symbol comment style is informally enforced by
+        # convention here, not by the linter.
+        - -ST1000
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        # QF1003 suggests tagged switches for two-clause string equality;
+        # the explicit if/||/elseif chain is clearer for the I/O-stream
+        # branching in storage/session.go and intentionally retained.
+        - -QF1003
+  exclusions:
+    rules:
+      - path: pkg/sudosrv_proto/
+        linters:
+          - errcheck
+          - gosec
+          - govet
+          - ineffassign
+          - modernize
+          - staticcheck
+          - unused
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gosec
+          - bodyclose

--- a/.modernize
+++ b/.modernize
@@ -1,0 +1,3 @@
+# Ignored modernization suggestions
+# Format: <date> <category> <description>
+2026-05-24 t-context internal/server/server_test.go:86 shutdown() helper is called from t.Cleanup blocks (api_e2e_test.go:45,199) where t.Context() is already canceled — using it would defeat apiServer.Shutdown's graceful drain. context.Background() with explicit 5s timeout is intentional.

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -207,7 +207,7 @@ func (s *Session) run() {
 		// context-aware reads/writes, so shutdown can interrupt stalled upstream I/O.
 		slog.Info("Upstream connection successful, flushing cache.", "log_id", s.logID, "file", s.cacheFileName)
 		err = flushFile(s.ctx, proc, s.cacheFileName, s.config)
-		proc.Close()
+		_ = proc.Close()
 		if err != nil {
 			// If ctx was cancelled, the error is expected (we closed the conn).
 			if s.ctx.Err() != nil {
@@ -571,7 +571,7 @@ func FlushOrphanedFile(ctx context.Context, filePath string, cfg *config.RelayCo
 	}
 
 	err = flushFile(ctx, proc, flushingFileName, cfg)
-	proc.Close()
+	_ = proc.Close()
 	if err != nil {
 		slog.Error("Failed to flush orphaned file, renaming back", "path", flushingFileName, "error", err)
 		if renameErr := os.Rename(flushingFileName, filePath); renameErr != nil {
@@ -678,14 +678,14 @@ func connectToUpstream(ctx context.Context, cfg *config.RelayConfig) (protocol.P
 	if err := withOperationTimeout(ctx, cfg, func(opCtx context.Context) error {
 		return proc.WriteClientMessageContext(opCtx, helloMsg)
 	}); err != nil {
-		proc.Close()
+		_ = proc.Close()
 		return nil, fmt.Errorf("failed to send ClientHello to upstream: %w", err)
 	}
 	if err := withOperationTimeout(ctx, cfg, func(opCtx context.Context) error {
 		_, err = proc.ReadServerMessageContext(opCtx)
 		return err
 	}); err != nil {
-		proc.Close()
+		_ = proc.Close()
 		return nil, fmt.Errorf("failed to receive ServerHello from upstream: %w", err)
 	}
 	return proc, nil

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -102,7 +102,7 @@ func (s *mockUpstreamServer) handleConnection(conn net.Conn) {
 	for {
 		msg, err := proc.ReadClientMessage()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				s.t.Logf("Mock server: client disconnected (EOF) after %d messages", messageCount)
 				return // Expected when the flushing client disconnects.
 			}
@@ -405,7 +405,7 @@ func TestRelayCommitPointThrottling(t *testing.T) {
 
 func TestRelaySession_CloseDoesNotWaitForFlush(t *testing.T) {
 	tmpDir := t.TempDir()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	relayCfg := &config.RelayConfig{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -427,7 +427,7 @@ func TestAcceptLoop_RejectsOverCap(t *testing.T) {
 	_, err = second.Read(buf)
 	if err == nil {
 		t.Errorf("read on rejected connection: got nil error, want EOF/close")
-	} else if err != io.EOF {
+	} else if !errors.Is(err, io.EOF) {
 		// Some platforms surface this as a different error (e.g., ECONNRESET);
 		// any non-nil read error is acceptable, just not nil/timeout.
 		var ne net.Error

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -18,7 +18,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"sudosrv/internal/config"
@@ -157,7 +156,12 @@ func writeNewFile(path string, data []byte, perm os.FileMode) (err error) {
 // containsDotDot checks whether a path contains a ".." component,
 // matching C sudo_logsrvd's contains_dot_dot() check.
 func containsDotDot(path string) bool {
-	return slices.Contains(strings.Split(filepath.ToSlash(path), "/"), "..")
+	for seg := range strings.SplitSeq(filepath.ToSlash(path), "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // pathWithinBase returns true when target stays lexically within base.

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -753,7 +753,7 @@ func (s *Session) initialize(acceptMsg *pb.AcceptMessage) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			for _, gzWriter := range s.gzipWriters {
-				gzWriter.Close()
+				_ = gzWriter.Close()
 			}
 			for _, f := range s.files {
 				f.Close()
@@ -1321,7 +1321,7 @@ func (s *Session) finalize(exitMsg *pb.ExitMessage) {
 	}
 
 	// Close all file handles
-	s.Close()
+	_ = s.Close()
 
 	// Mark timing file as read-only to indicate completion, per sudo spec.
 	timingFilePath := filepath.Join(s.sessionDir, "timing")


### PR DESCRIPTION
## Summary

- Apply three modernization findings from `/golang-modernize` (Go 1.26.3 baseline): `errors.Is` for `io.EOF`, `t.Context()` in the relay cancellation test, `strings.SplitSeq` in `containsDotDot`.
- Add `.golangci.yml` (v2 config) and wire up `lint` + `govulncheck` GitHub Actions jobs, running in parallel with the existing build/test job.
- Drive-by fixes the lint run surfaced: a second `err != io.EOF` direct comparison, plus making intentional `Close()` discards explicit with `_ =`.

## Why

The `modernize` linter reported 0 issues, but a deeper scan still found three idioms worth updating. More importantly, the project had no static analysis or vulnerability scanning in CI — just build + test. This PR closes that gap with a project-tuned linter config that documents inline why each silenced rule is a deliberate codebase decision (validated path building, length-prefix conversions, config-controlled TLS toggles, jitter-only `math/rand/v2`, sudoreplay-compatible 0440 timing file).

## How

**Modernization (commit 1)**
- `internal/relay/session_test.go`: `err == io.EOF` → `errors.Is(err, io.EOF)`; `context.Background()` → `t.Context()` in `TestRelaySession_CloseDoesNotWaitForFlush`.
- `internal/storage/session.go`: `containsDotDot` now iterates via `strings.SplitSeq` to short-circuit on the first `..` segment without allocating `[]string`; drops the `slices` import.
- `.modernize`: documents why `internal/server/server_test.go:86` *intentionally* keeps `context.Background()` — `shutdown()` is invoked from `t.Cleanup` blocks where `t.Context()` would already be canceled and defeat the graceful drain.

**CI tooling (commit 2)**
- `.golangci.yml`: v2 config targeting Go 1.26. Enables `bodyclose`, `copyloopvar`, `errorlint`, `gosec`, `intrange`, `modernize` on top of the standard set; each silenced gosec/staticcheck rule is documented inline with the codebase rationale.
- `.github/workflows/makefile.yml`: new `lint` (golangci-lint v2.12.2 via `golangci-lint-action@v7`) and `govulncheck` (`govulncheck-action@v1`) jobs in parallel with the existing build/test job.
- `internal/server/server_test.go`: `!errors.Is(err, io.EOF)` for the second EOF-comparison bug the lint run caught.
- `internal/relay/session.go`, `internal/storage/session.go`: 5 `Close()` calls now explicitly `_ = ...` to mark the discard as intentional.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` all packages pass
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `govulncheck ./...` reports no vulnerabilities
- [ ] CI lint job passes on the PR
- [ ] CI govulncheck job passes on the PR
- [ ] CI build/test job remains green