### PR TITLE
Fix wire/behavior incompatibilities with reference sudo_logsrvd (1.9.18)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -126,6 +126,11 @@ func (s *Server) Listen() error {
 // stapling, custom curve preferences) lives in one place. TLS 1.3 is the
 // floor — its cipher suites are not configurable and are all AEAD, so we
 // don't enumerate CipherSuites (those entries would be silently ignored).
+//
+// Unlike the sudo protocol surfaces (server.tls_min_version / relay.tls_min_version,
+// which may be lowered to 1.2 for legacy peers), the management API is pinned to
+// TLS 1.3: it is a new admin-only endpoint with no legacy-client compatibility
+// requirement, so there is no reason to weaken its floor.
 func buildTLSConfig(cfg config.APIConfig) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"os"
@@ -12,6 +13,21 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+// TLSVersion maps a "1.2"/"1.3" config string to the crypto/tls version
+// constant. An empty string defaults to TLS 1.3 (the secure default), so
+// manually-constructed configs that omit the field still resolve. Any other
+// value is rejected so a typo cannot silently weaken the floor.
+func TLSVersion(s string) (uint16, error) {
+	switch s {
+	case "", "1.3":
+		return tls.VersionTLS13, nil
+	case "1.2":
+		return tls.VersionTLS12, nil
+	default:
+		return 0, fmt.Errorf("unsupported tls_min_version %q (supported: \"1.2\", \"1.3\")", s)
+	}
+}
 
 // Config holds the application's configuration.
 type Config struct {
@@ -28,6 +44,7 @@ type ServerConfig struct {
 	ListenAddressTLS          string        `yaml:"listen_address_tls"`
 	TLSCertFile               string        `yaml:"tls_cert_file"`
 	TLSKeyFile                string        `yaml:"tls_key_file"`
+	TLSMinVersion             string        `yaml:"tls_min_version"` // "1.2" or "1.3" (default "1.3") for the protocol TLS listener
 	ServerID                  string        `yaml:"server_id"`
 	IdleTimeout               time.Duration `yaml:"idle_timeout"`
 	MaxConnections            int           `yaml:"max_connections"`              // 0 disables the cap
@@ -39,6 +56,7 @@ type RelayConfig struct {
 	UpstreamHost         string        `yaml:"upstream_host"`
 	UseTLS               bool          `yaml:"use_tls"`
 	TLSSkipVerify        bool          `yaml:"tls_skip_verify"`
+	TLSMinVersion        string        `yaml:"tls_min_version"` // "1.2" or "1.3" (default "1.3") for the upstream dial
 	ConnectTimeout       time.Duration `yaml:"connect_timeout"`
 	RelayCacheDirectory  string        `yaml:"relay_cache_directory"`
 	ReconnectAttempts    int           `yaml:"reconnect_attempts"`
@@ -116,6 +134,7 @@ func defaultConfig() *Config {
 			ServerID:                  "GoSudoLogSrv/1.0",
 			IdleTimeout:               10 * time.Minute,
 			MaxConnections:            10000,
+			TLSMinVersion:             "1.3", // Secure default; "1.2" available for legacy clients
 			ServerOperationalLogLevel: "info", // Default log level
 		},
 		Relay: RelayConfig{
@@ -124,6 +143,7 @@ func defaultConfig() *Config {
 			ReconnectAttempts:    -1, // Default to trying forever
 			MaxReconnectInterval: 1 * time.Minute,
 			TLSSkipVerify:        false, // Default to secure TLS verification
+			TLSMinVersion:        "1.3", // Secure default; "1.2" available for legacy upstreams
 		},
 		LocalStorage: LocalStorageConfig{
 			LogDirectory:    "/var/log/gosudo-io",
@@ -164,6 +184,12 @@ func applyZeroValueDefaults(cfg *Config) {
 	if cfg.Server.MaxConnections < 0 {
 		cfg.Server.MaxConnections = 0
 	}
+	if cfg.Server.TLSMinVersion == "" {
+		cfg.Server.TLSMinVersion = "1.3"
+	}
+	if cfg.Relay.TLSMinVersion == "" {
+		cfg.Relay.TLSMinVersion = "1.3"
+	}
 	if cfg.LocalStorage.DirPermissions == 0 {
 		cfg.LocalStorage.DirPermissions = 0750
 	}
@@ -198,6 +224,12 @@ func Validate(cfg *Config) error {
 		if cfg.Server.TLSCertFile == "" || cfg.Server.TLSKeyFile == "" {
 			return fmt.Errorf("TLS certificate and key files must be specified for TLS listener")
 		}
+	}
+	if _, err := TLSVersion(cfg.Server.TLSMinVersion); err != nil {
+		return fmt.Errorf("server.%w", err)
+	}
+	if _, err := TLSVersion(cfg.Relay.TLSMinVersion); err != nil {
+		return fmt.Errorf("relay.%w", err)
 	}
 	if cfg.Server.Mode == "relay" {
 		if cfg.Relay.UpstreamHost == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,12 @@ func unmarshalConfig(data []byte, config *Config) error {
 // applyZeroValueDefaults restores default values for fields that yaml.Unmarshal
 // may have zeroed when a section was partially specified.
 func applyZeroValueDefaults(cfg *Config) {
+	// idle_timeout: a zero value (the field omitted, or "0s") is treated as
+	// "use the default" and restored to 10m, guarding a partially specified
+	// server section from accidentally zeroing it. A NEGATIVE value (e.g.
+	// "idle_timeout: -1s") is preserved and means "no read timeout", matching
+	// the reference C sudo_logsrvd, which never disconnects an idle client; the
+	// connection handler skips arming a read deadline when IdleTimeout <= 0.
 	if cfg.Server.IdleTimeout == 0 {
 		cfg.Server.IdleTimeout = 10 * time.Minute
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,7 +134,7 @@ func defaultConfig() *Config {
 			ServerID:                  "GoSudoLogSrv/1.0",
 			IdleTimeout:               10 * time.Minute,
 			MaxConnections:            10000,
-			TLSMinVersion:             "1.3", // Secure default; "1.2" available for legacy clients
+			TLSMinVersion:             "1.3",  // Secure default; "1.2" available for legacy clients
 			ServerOperationalLogLevel: "info", // Default log level
 		},
 		Relay: RelayConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -654,6 +655,91 @@ func TestIdleTimeoutNegativeIsPreserved(t *testing.T) {
 		}
 		if cfg.Server.IdleTimeout != 10*time.Minute {
 			t.Errorf("idle_timeout: got %v, want 10m default when omitted", cfg.Server.IdleTimeout)
+		}
+	})
+}
+
+// TestTLSVersion verifies the "1.2"/"1.3" string maps to the right crypto/tls
+// constant, that an empty string defaults to the secure 1.3 floor, and that a
+// bad value is rejected (so a typo cannot silently weaken TLS).
+func TestTLSVersion(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    uint16
+		wantErr bool
+	}{
+		{"1.3", tls.VersionTLS13, false},
+		{"", tls.VersionTLS13, false},
+		{"1.2", tls.VersionTLS12, false},
+		{"1.1", 0, true},
+		{"garbage", 0, true},
+	}
+	for _, c := range cases {
+		got, err := TLSVersion(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("TLSVersion(%q): expected error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("TLSVersion(%q): unexpected error %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("TLSVersion(%q) = %#x, want %#x", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTLSMinVersionConfig verifies the secure 1.3 default, the documented 1.2
+// opt-in for legacy peers (server + relay), and that Validate rejects an invalid
+// value.
+func TestTLSMinVersionConfig(t *testing.T) {
+	t.Run("DefaultIs13", func(t *testing.T) {
+		cfg := defaultConfig()
+		if cfg.Server.TLSMinVersion != "1.3" || cfg.Relay.TLSMinVersion != "1.3" {
+			t.Fatalf("defaults: server=%q relay=%q, want 1.3/1.3", cfg.Server.TLSMinVersion, cfg.Relay.TLSMinVersion)
+		}
+	})
+
+	t.Run("OptInTo12", func(t *testing.T) {
+		content := "server:\n  mode: \"local\"\n  tls_min_version: \"1.2\"\nrelay:\n  tls_min_version: \"1.2\"\n"
+		tmpFile := filepath.Join(t.TempDir(), "c.yaml")
+		if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := LoadConfig(tmpFile)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.Server.TLSMinVersion != "1.2" || cfg.Relay.TLSMinVersion != "1.2" {
+			t.Fatalf("got server=%q relay=%q, want 1.2/1.2", cfg.Server.TLSMinVersion, cfg.Relay.TLSMinVersion)
+		}
+		if v, _ := TLSVersion(cfg.Server.TLSMinVersion); v != tls.VersionTLS12 {
+			t.Errorf("resolved server min = %#x, want TLS 1.2", v)
+		}
+	})
+
+	t.Run("OmittedDefaultsTo13", func(t *testing.T) {
+		content := "server:\n  mode: \"local\"\n"
+		tmpFile := filepath.Join(t.TempDir(), "c.yaml")
+		if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := LoadConfig(tmpFile)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.Server.TLSMinVersion != "1.3" {
+			t.Errorf("omitted server tls_min_version = %q, want 1.3", cfg.Server.TLSMinVersion)
+		}
+	})
+
+	t.Run("ValidateRejectsBadVersion", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Server.TLSMinVersion = "1.1"
+		if err := Validate(cfg); err == nil {
+			t.Error("expected Validate to reject tls_min_version 1.1")
 		}
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -618,3 +618,42 @@ func TestApplyZeroValueDefaults(t *testing.T) {
 		}
 	})
 }
+
+// TestIdleTimeoutNegativeIsPreserved verifies that a negative idle_timeout is
+// preserved (not re-defaulted to 10m). A negative value is the opt-out sentinel
+// for "no read timeout", matching the reference C sudo_logsrvd which never
+// disconnects an idle client. A zero/omitted value still restores the default.
+func TestIdleTimeoutNegativeIsPreserved(t *testing.T) {
+	t.Run("NegativeDisablesAndIsPreserved", func(t *testing.T) {
+		content := "server:\n  mode: \"local\"\n  idle_timeout: -1s\n"
+		tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
+			t.Fatalf("write temp config: %v", err)
+		}
+		cfg, err := LoadConfig(tmpFile)
+		if err != nil {
+			t.Fatalf("LoadConfig() error: %v", err)
+		}
+		if cfg.Server.IdleTimeout != -1*time.Second {
+			t.Errorf("idle_timeout: got %v, want -1s (negative must be preserved, not re-defaulted)", cfg.Server.IdleTimeout)
+		}
+		if cfg.Server.IdleTimeout > 0 {
+			t.Errorf("idle_timeout %v should be non-positive so the handler skips the read deadline", cfg.Server.IdleTimeout)
+		}
+	})
+
+	t.Run("OmittedRestoresDefault", func(t *testing.T) {
+		content := "server:\n  mode: \"local\"\n"
+		tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
+			t.Fatalf("write temp config: %v", err)
+		}
+		cfg, err := LoadConfig(tmpFile)
+		if err != nil {
+			t.Fatalf("LoadConfig() error: %v", err)
+		}
+		if cfg.Server.IdleTimeout != 10*time.Minute {
+			t.Errorf("idle_timeout: got %v, want 10m default when omitted", cfg.Server.IdleTimeout)
+		}
+	})
+}

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -198,13 +198,13 @@ func (h *Handler) Handle() {
 			}
 		}
 
-		// Apply rate limiting to prevent memory exhaustion.
-		// All writes below use h.ctx so a stalled client can't pin the handler
-		// past shutdown — see Server.Wait's bounded grace period.
-		if !h.checkRateLimit() {
-			slog.Warn("Rate limit exceeded, closing connection", "remote_addr", h.conn.RemoteAddr())
-			errMsg := &pb.ServerMessage{Type: &pb.ServerMessage_Error{Error: "Rate limit exceeded"}}
-			_ = h.processor.WriteServerMessageContext(h.ctx, errMsg)
+		// Apply rate limiting as back-pressure: this blocks until a token is
+		// available rather than closing the connection, so a legitimate
+		// high-throughput session is throttled, not severed. It returns early
+		// only on context cancellation (shutdown), so a stalled client can't pin
+		// the handler past shutdown — see Server.Wait's bounded grace period.
+		if err := h.waitForRateToken(h.ctx); err != nil {
+			slog.Debug("Connection handler stopping while rate-limited", "remote_addr", h.conn.RemoteAddr(), "error", err)
 			return
 		}
 
@@ -369,29 +369,56 @@ func (h *Handler) handleHello() (*pb.ServerMessage, error) {
 	return &pb.ServerMessage{Type: &pb.ServerMessage_Hello{Hello: helloResponse}}, nil
 }
 
-// checkRateLimit implements token-bucket rate limiting to prevent memory
-// exhaustion attacks. Each connection is refilled at rateRefillPerSec tokens/sec
-// up to rateBurst; each processed message consumes one token. Unlike a simple
-// windowed counter, this correctly smooths bursts that straddle second boundaries.
-func (h *Handler) checkRateLimit() bool {
-	h.rateLimitMutex.Lock()
-	defer h.rateLimitMutex.Unlock()
-
-	now := time.Now()
-	elapsed := now.Sub(h.rateLastRefill).Seconds()
-	if elapsed > 0 {
-		h.rateTokens += elapsed * rateRefillPerSec
-		if h.rateTokens > rateBurst {
-			h.rateTokens = rateBurst
+// waitForRateToken implements token-bucket rate limiting to bound the rate at
+// which a single connection's messages are processed. Each connection is
+// refilled at rateRefillPerSec tokens/sec up to rateBurst; each processed
+// message consumes one token. The token-bucket smooths bursts that straddle
+// second boundaries.
+//
+// When the bucket is empty this BLOCKS until the next token refills (returning
+// only on context cancellation) rather than terminating the connection. This is
+// deliberate: the reference C sudo_logsrvd imposes no application-level rate
+// limit, and a legitimate high-throughput session (a verbose build, `yes`, a
+// large `cat`) routinely emits hundreds of ttyout buffers in a sub-second burst.
+// Closing the connection on excess would truncate such a session and make the
+// stock client report a fatal log error. Blocking instead applies back-pressure:
+// the handler stops reading, TCP flow control slows the client, and no audit
+// data is lost. Memory stays bounded because at most one message is held in
+// flight while we wait.
+func (h *Handler) waitForRateToken(ctx context.Context) error {
+	for {
+		h.rateLimitMutex.Lock()
+		now := time.Now()
+		elapsed := now.Sub(h.rateLastRefill).Seconds()
+		if elapsed > 0 {
+			h.rateTokens += elapsed * rateRefillPerSec
+			if h.rateTokens > rateBurst {
+				h.rateTokens = rateBurst
+			}
+			h.rateLastRefill = now
 		}
-		h.rateLastRefill = now
-	}
+		if h.rateTokens >= 1 {
+			h.rateTokens--
+			h.rateLimitMutex.Unlock()
+			return nil
+		}
+		// Bucket empty: compute how long until one token refills, then sleep
+		// (without holding the mutex) before re-checking. The deficit is < 1
+		// token, so the wait is at most 1/rateRefillPerSec seconds.
+		wait := time.Duration((1 - h.rateTokens) / rateRefillPerSec * float64(time.Second))
+		h.rateLimitMutex.Unlock()
+		if wait <= 0 {
+			wait = time.Millisecond // floor to avoid a busy spin on rounding
+		}
 
-	if h.rateTokens < 1 {
-		return false
+		timer := time.NewTimer(wait)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		}
 	}
-	h.rateTokens--
-	return true
 }
 
 // applyRuncwdFallback implements the three-tier fallback logic for runcwd as per sudo logging.c:1008-1014.

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -46,6 +46,7 @@ type Handler struct {
 		newLocalEventSession   func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
 		newRelaySession        func(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.RelayConfig) (SessionHandler, error)
 		newLocalRestartSession func(restartMsg *pb.RestartMessage, cfg *config.LocalStorageConfig) (SessionHandler, error)
+		newRelayRestartSession func(restartMsg *pb.RestartMessage, cfg *config.RelayConfig) (SessionHandler, error)
 	}
 }
 
@@ -137,6 +138,19 @@ func NewHandlerWithContext(ctx context.Context, conn net.Conn, cfg *config.Confi
 	}
 	h.sessionFactories.newLocalRestartSession = func(restartMsg *pb.RestartMessage, localCfg *config.LocalStorageConfig) (SessionHandler, error) {
 		return storage.NewRestartSession(restartMsg, localCfg)
+	}
+	h.sessionFactories.newRelayRestartSession = func(restartMsg *pb.RestartMessage, relayCfg *config.RelayConfig) (SessionHandler, error) {
+		// Like newRelaySession, the relay restart session self-deregisters when
+		// its background flusher exits. The registry key is the restart log_id,
+		// matching registerRestartSession's h.sessionID.
+		logID := restartMsg.GetLogId()
+		onDone := func() {
+			if h.registry != nil {
+				h.registry.Deregister(logID)
+			}
+			metrics.Global.DecrementActiveSessions()
+		}
+		return relay.NewRestartSession(h.ctx, restartMsg, relayCfg, onDone)
 	}
 	return h
 }
@@ -333,7 +347,7 @@ func (h *Handler) registerSession(sessionUUID uuid.UUID, mode string, acceptMsg 
 // registerRestartSession is the restart-path equivalent of registerSession.
 // Restart sessions resume an existing log, so the base64 log_id is provided
 // up-front by the client and used as the registry key directly.
-func (h *Handler) registerRestartSession(restartMsg *pb.RestartMessage) {
+func (h *Handler) registerRestartSession(restartMsg *pb.RestartMessage, mode string) {
 	if h.registry == nil || h.session == nil {
 		return
 	}
@@ -341,7 +355,7 @@ func (h *Handler) registerRestartSession(restartMsg *pb.RestartMessage) {
 	info := sessions.SessionInfo{
 		SessionID:   h.sessionID,
 		ServerLogID: restartMsg.GetLogId(),
-		Mode:        "local",
+		Mode:        mode,
 		RemoteAddr:  h.conn.RemoteAddr().String(),
 		StartedAt:   h.startedAt,
 		Info:        map[string]any{"event_type": "restart"},
@@ -353,6 +367,12 @@ func (h *Handler) registerRestartSession(restartMsg *pb.RestartMessage) {
 		info.Provider = p
 	}
 	h.registry.Register(info)
+	// Same race guard as registerSession: a self-deregistering (relay) session
+	// whose runner finished before we registered would have had its onDone
+	// Deregister no-op; detect that and remove our just-added entry.
+	if d, ok := h.session.(doneNotifier); ok && d.IsDone() {
+		h.registry.Deregister(h.sessionID)
+	}
 }
 
 // refreshLogIDFromSession overwrites h.logID with the session's authoritative
@@ -552,25 +572,45 @@ func (h *Handler) handleReject(rejectMsg *pb.RejectMessage) (*pb.ServerMessage, 
 
 // handleRestart resumes an existing session from a RestartMessage.
 func (h *Handler) handleRestart(restartMsg *pb.RestartMessage) (*pb.ServerMessage, error) {
-	if h.config.Server.Mode != "local" {
+	switch h.config.Server.Mode {
+	case "local":
+		session, err := h.sessionFactories.newLocalRestartSession(restartMsg, &h.config.LocalStorage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create restart session: %w", err)
+		}
+		h.session = session
+		h.logID = restartMsg.GetLogId()
+		h.registerRestartSession(restartMsg, "local")
+		metrics.Global.IncrementSessions()
+		metrics.Global.IncrementLocalSessions()
+		slog.Info("Resumed local storage session via restart",
+			"log_id", h.logID, "total_sessions", metrics.Global.GetTotalSessions())
+		return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: restartMsg.GetLogId()}}, nil
+
+	case "relay":
+		// Resume locally by appending to the still-cached session (see
+		// relay.NewRestartSession). Go's batch relay cannot forward the restart
+		// upstream the way C does, because the upstream never saw the original
+		// session and the client holds a relay-local log_id.
+		session, err := h.sessionFactories.newRelayRestartSession(restartMsg, &h.config.Relay)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resume relay session: %w", err)
+		}
+		h.session = session
+		h.logID = restartMsg.GetLogId()
+		h.registerRestartSession(restartMsg, "relay")
+		metrics.Global.IncrementSessions()
+		metrics.Global.IncrementRelaySessions()
+		slog.Info("Resumed relay session via restart",
+			"log_id", h.logID, "upstream", h.config.Relay.UpstreamHost,
+			"total_sessions", metrics.Global.GetTotalSessions())
+		// The client transitions straight to SEND_IO after a RestartMessage and
+		// does not await a reply, so we send none (avoiding an extra log_id msg).
+		return nil, nil
+
+	default:
 		return nil, fmt.Errorf("restart not supported in %s mode", h.config.Server.Mode)
 	}
-
-	session, err := h.sessionFactories.newLocalRestartSession(restartMsg, &h.config.LocalStorage)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create restart session: %w", err)
-	}
-
-	h.session = session
-	h.logID = restartMsg.GetLogId()
-	h.registerRestartSession(restartMsg)
-	metrics.Global.IncrementSessions()
-	metrics.Global.IncrementLocalSessions()
-	slog.Info("Resumed local storage session via restart",
-		"log_id", h.logID,
-		"total_sessions", metrics.Global.GetTotalSessions())
-
-	return &pb.ServerMessage{Type: &pb.ServerMessage_LogId{LogId: restartMsg.GetLogId()}}, nil
 }
 
 // handleAccept sets up a session for an accepted command.

--- a/internal/connection/handler.go
+++ b/internal/connection/handler.go
@@ -180,9 +180,16 @@ func (h *Handler) Handle() {
 		default:
 		}
 
-		if err := h.conn.SetReadDeadline(time.Now().Add(h.config.Server.IdleTimeout)); err != nil {
-			slog.Error("Failed to set read deadline", "error", err)
-			return
+		// Arm a per-message idle read deadline. A non-positive IdleTimeout means
+		// "no read timeout", matching the reference C sudo_logsrvd, which adds its
+		// steady-state read event with a NULL timeout so an idle-but-alive client
+		// (e.g. an interactive shell left at a prompt) is never disconnected for
+		// inactivity. Operators opt into that parity with idle_timeout: -1s.
+		if h.config.Server.IdleTimeout > 0 {
+			if err := h.conn.SetReadDeadline(time.Now().Add(h.config.Server.IdleTimeout)); err != nil {
+				slog.Error("Failed to set read deadline", "error", err)
+				return
+			}
 		}
 
 		clientMsg, err := h.processor.ReadClientMessage()

--- a/internal/connection/handler_test.go
+++ b/internal/connection/handler_test.go
@@ -3,6 +3,7 @@
 package connection
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"os"
@@ -1138,4 +1139,52 @@ func TestRelay_DoneBeforeRegisterDoesNotOrphan(t *testing.T) {
 
 	serverConn.Close()
 	wg.Wait()
+}
+
+// TestWaitForRateToken verifies that exceeding the per-connection rate limit
+// applies back-pressure (blocks until a token refills) instead of terminating
+// the connection — the reference C sudo_logsrvd has no such limit, and a
+// legitimate high-throughput session must not be severed. It also verifies the
+// wait is abortable via context so shutdown is never pinned by a slow client.
+func TestWaitForRateToken(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Mode: "local", IdleTimeout: time.Second, ServerID: "t"},
+	}
+	_, serverConn := net.Pipe()
+	defer serverConn.Close()
+	h := NewHandler(serverConn, cfg)
+
+	// The initial burst (rateBurst tokens) drains effectively instantly.
+	start := time.Now()
+	for range int(rateBurst) {
+		if err := h.waitForRateToken(context.Background()); err != nil {
+			t.Fatalf("unexpected error draining burst: %v", err)
+		}
+	}
+	if d := time.Since(start); d > 250*time.Millisecond {
+		t.Fatalf("draining the burst took %s, expected near-instant", d)
+	}
+
+	// With the bucket empty the next token must BLOCK and then SUCCEED — never
+	// return an error (which the caller turns into a connection teardown). It
+	// should take roughly one refill interval (1/rateRefillPerSec).
+	start = time.Now()
+	if err := h.waitForRateToken(context.Background()); err != nil {
+		t.Fatalf("expected back-pressure (block then succeed), got error: %v", err)
+	}
+	if d := time.Since(start); d < 5*time.Millisecond {
+		t.Errorf("expected throttle delay ~%v, got %s (was it actually throttled?)", time.Second/time.Duration(rateRefillPerSec), d)
+	}
+
+	// Force the bucket empty, then a cancelled context must abort the wait
+	// promptly rather than blocking forever.
+	h.rateLimitMutex.Lock()
+	h.rateTokens = 0
+	h.rateLastRefill = time.Now()
+	h.rateLimitMutex.Unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := h.waitForRateToken(ctx); err == nil {
+		t.Error("expected cancellation error while rate-limited, got nil")
+	}
 }

--- a/internal/connection/handler_test.go
+++ b/internal/connection/handler_test.go
@@ -1188,3 +1188,75 @@ func TestWaitForRateToken(t *testing.T) {
 		t.Error("expected cancellation error while rate-limited, got nil")
 	}
 }
+
+// deadlineRecorderConn wraps a net.Conn and records SetReadDeadline calls so a
+// test can assert whether the handler armed a per-message idle read deadline.
+type deadlineRecorderConn struct {
+	net.Conn
+	mu           sync.Mutex
+	setCalls     int
+	lastDeadline time.Time
+}
+
+func (c *deadlineRecorderConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.setCalls++
+	c.lastDeadline = t
+	c.mu.Unlock()
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *deadlineRecorderConn) calls() (int, time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.setCalls, c.lastDeadline
+}
+
+// TestIdleReadDeadlineOptOut verifies that a non-positive idle_timeout disables
+// the per-message read deadline (matching C sudo_logsrvd's NULL read timeout),
+// while a positive value still arms it.
+func TestIdleReadDeadlineOptOut(t *testing.T) {
+	exchangeHello := func(t *testing.T, idle time.Duration) *deadlineRecorderConn {
+		t.Helper()
+		cfg := &config.Config{Server: config.ServerConfig{Mode: "local", IdleTimeout: idle, ServerID: "t"}}
+		clientConn, serverConn := net.Pipe()
+		rec := &deadlineRecorderConn{Conn: serverConn}
+		h := NewHandler(rec, cfg)
+		var wg sync.WaitGroup
+		wg.Go(h.Handle)
+
+		clientProc := protocol.NewProcessor(clientConn, clientConn)
+		if err := clientProc.WriteClientMessage(&pb.ClientMessage{
+			Type: &pb.ClientMessage_HelloMsg{HelloMsg: &pb.ClientHello{ClientId: "x"}},
+		}); err != nil {
+			t.Fatalf("client write Hello: %v", err)
+		}
+		if _, err := clientProc.ReadServerMessage(); err != nil {
+			t.Fatalf("client read ServerHello: %v", err)
+		}
+		// The loop has processed one message and is back at the top of the next
+		// iteration (where the deadline is armed) before blocking on read.
+		clientConn.Close()
+		serverConn.Close()
+		wg.Wait()
+		return rec
+	}
+
+	t.Run("NegativeDisablesReadDeadline", func(t *testing.T) {
+		rec := exchangeHello(t, -1*time.Second)
+		if n, _ := rec.calls(); n != 0 {
+			t.Errorf("expected 0 SetReadDeadline calls with idle_timeout<=0, got %d", n)
+		}
+	})
+
+	t.Run("PositiveArmsReadDeadline", func(t *testing.T) {
+		rec := exchangeHello(t, 30*time.Second)
+		n, last := rec.calls()
+		if n == 0 {
+			t.Error("expected SetReadDeadline to be armed with a positive idle_timeout")
+		}
+		if !last.After(time.Now()) {
+			t.Errorf("expected a future read deadline, got %v", last)
+		}
+	})
+}

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -69,10 +69,10 @@ type Session struct {
 	// flipping the closed flag and closing the channel. Without this,
 	// a sender that passed the closed check could still write to a buffer
 	// the writer goroutine has already abandoned, silently losing audit data.
-	sendMu    sync.RWMutex
-	closed    atomic.Bool // mutated under sendMu.Lock; read under sendMu.RLock
-	wg        sync.WaitGroup
-	closeOnce sync.Once
+	sendMu          sync.RWMutex
+	closed          atomic.Bool // mutated under sendMu.Lock; read under sendMu.RLock
+	wg              sync.WaitGroup
+	closeOnce       sync.Once
 	cacheFileName   string
 	mu              sync.Mutex    // Protects cumulativeDelay and lastCommitTime
 	cumulativeDelay time.Duration // Single elapsed clock summed across all I/O, winsize, and suspend delays (mirrors C closure->elapsed_time)

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -70,9 +70,9 @@ type Session struct {
 	wg        sync.WaitGroup
 	closeOnce sync.Once
 	cacheFileName   string
-	mu              sync.Mutex               // Protects cumulativeDelay and lastCommitTime
-	cumulativeDelay map[string]time.Duration // Tracks cumulative I/O delay per stream for commit points
-	lastCommitTime  time.Time                // When last commit point was sent to client
+	mu              sync.Mutex    // Protects cumulativeDelay and lastCommitTime
+	cumulativeDelay time.Duration // Single elapsed clock summed across all I/O, winsize, and suspend delays (mirrors C closure->elapsed_time)
+	lastCommitTime  time.Time     // When last commit point was sent to client
 	ctx             context.Context
 	cancel          context.CancelFunc
 	// onDone is invoked exactly once after the background runner exits — i.e.
@@ -131,7 +131,6 @@ func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.Accept
 		initialAcceptMsg: acceptMsg,
 		fromClientChan:   make(chan *pb.ClientMessage, 1000), // Buffered channel for client messages
 		cacheFileName:    cacheFileName,
-		cumulativeDelay:  make(map[string]time.Duration),
 		ctx:              ctx,
 		cancel:           cancel,
 		onDone:           onDone,
@@ -340,6 +339,54 @@ func extractIoDelay(msg *pb.ClientMessage) (string, *pb.TimeSpec) {
 	}
 }
 
+// messageDelay returns the delay of any event that advances sudo's elapsed-time
+// clock: the five I/O buffers plus winsize and suspend. Returns nil for messages
+// that carry no delay (Accept/Reject/Restart/Alert/Exit). Mirrors the set of
+// update_elapsed_time call sites in C sudo_logsrvd.
+func messageDelay(msg *pb.ClientMessage) *pb.TimeSpec {
+	switch event := msg.Type.(type) {
+	case *pb.ClientMessage_TtyinBuf:
+		return event.TtyinBuf.GetDelay()
+	case *pb.ClientMessage_TtyoutBuf:
+		return event.TtyoutBuf.GetDelay()
+	case *pb.ClientMessage_StdinBuf:
+		return event.StdinBuf.GetDelay()
+	case *pb.ClientMessage_StdoutBuf:
+		return event.StdoutBuf.GetDelay()
+	case *pb.ClientMessage_StderrBuf:
+		return event.StderrBuf.GetDelay()
+	case *pb.ClientMessage_WinsizeEvent:
+		return event.WinsizeEvent.GetDelay()
+	case *pb.ClientMessage_SuspendEvent:
+		return event.SuspendEvent.GetDelay()
+	default:
+		return nil
+	}
+}
+
+// isExitMessage reports whether msg is an ExitMessage.
+func isExitMessage(msg *pb.ClientMessage) bool {
+	_, ok := msg.Type.(*pb.ClientMessage_ExitMsg)
+	return ok
+}
+
+// durationFromTimeSpec converts a protobuf TimeSpec into a time.Duration.
+func durationFromTimeSpec(ts *pb.TimeSpec) time.Duration {
+	return time.Duration(ts.GetTvSec())*time.Second + time.Duration(ts.GetTvNsec())*time.Nanosecond
+}
+
+// commitPointMsg builds a commit_point ServerMessage carrying the cumulative
+// elapsed time d. Integer second/nanosecond split matches C's encoding and the
+// value the client compares against its own global elapsed time.
+func commitPointMsg(d time.Duration) *pb.ServerMessage {
+	return &pb.ServerMessage{Type: &pb.ServerMessage_CommitPoint{
+		CommitPoint: &pb.TimeSpec{
+			TvSec:  int64(d / time.Second),
+			TvNsec: int32(d % time.Second),
+		},
+	}}
+}
+
 // LogID returns the base64-encoded sudo log_id assigned when the relay session
 // was created. It is stable for the lifetime of the session.
 func (s *Session) LogID() string { return s.logID }
@@ -396,28 +443,36 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 		return nil, fmt.Errorf("relay session cancelled")
 	}
 
-	// Generate local commit points for relay clients on I/O events,
-	// throttled to commitPointInterval matching C sudo_logsrvd behavior.
-	// Lock protects cumulativeDelay and lastCommitTime which are also
-	// read by the run() goroutine's context (indirectly via Close/wg.Wait).
-	if streamName, delay := extractIoDelay(msg); streamName != "" {
+	// Generate local commit points for the downstream client so it can complete
+	// its CLOSING handshake without waiting on the (asynchronously flushed)
+	// upstream. The cumulative clock is advanced by EVERY delay-bearing event
+	// (I/O, winsize, suspend) — one counter, mirroring C's closure->elapsed_time —
+	// because the client compares the final commit_point against its own global
+	// elapsed time. Lock protects cumulativeDelay and lastCommitTime which are
+	// also read by the run() goroutine's context (indirectly via Close/wg.Wait).
+	streamName, _ := extractIoDelay(msg)
+	if delay := messageDelay(msg); delay != nil {
 		s.mu.Lock()
-		if delay != nil {
-			delayDur := time.Duration(delay.TvSec)*time.Second + time.Duration(delay.TvNsec)*time.Nanosecond
-			s.cumulativeDelay[streamName] += delayDur
-		}
-		if time.Since(s.lastCommitTime) >= commitPointInterval {
+		s.cumulativeDelay += durationFromTimeSpec(delay)
+		// Throttled periodic commit on I/O events (matches C's ACK_FREQUENCY).
+		// winsize/suspend advance the clock but do not themselves emit a commit.
+		if streamName != "" && time.Since(s.lastCommitTime) >= commitPointInterval {
 			s.lastCommitTime = time.Now()
-			commitPoint := s.cumulativeDelay[streamName]
+			cp := s.cumulativeDelay
 			s.mu.Unlock()
-			return &pb.ServerMessage{Type: &pb.ServerMessage_CommitPoint{
-				CommitPoint: &pb.TimeSpec{
-					TvSec:  int64(commitPoint / time.Second),
-					TvNsec: int32(commitPoint % time.Second),
-				},
-			}}, nil
+			return commitPointMsg(cp), nil
 		}
 		s.mu.Unlock()
+	}
+
+	// Unconditional FINAL commit on Exit (matches C handle_exit). Exit carries no
+	// delay so it is handled outside the accumulation block above; without this
+	// the stock client stalls in CLOSING until log_server_timeout (default 30s).
+	if isExitMessage(msg) {
+		s.mu.Lock()
+		cp := s.cumulativeDelay
+		s.mu.Unlock()
+		return commitPointMsg(cp), nil
 	}
 
 	return nil, nil

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -57,7 +57,11 @@ type Session struct {
 	logID            string
 	config           *config.RelayConfig
 	initialAcceptMsg *pb.AcceptMessage
-	fromClientChan   chan *pb.ClientMessage
+	// resume is true for a session created via NewRestartSession: it appends the
+	// resumed I/O to an existing cache file (which already begins with the
+	// original AcceptMessage) instead of writing a fresh AcceptMessage opener.
+	resume         bool
+	fromClientChan chan *pb.ClientMessage
 	// sendMu serializes Close against in-flight HandleClientMessage calls.
 	// HandleClientMessage holds RLock for its entire critical section
 	// (closed check + channel send); Close takes the exclusive Lock so it
@@ -139,6 +143,62 @@ func NewSession(ctx context.Context, sessionUUID uuid.UUID, acceptMsg *pb.Accept
 
 	s.wg.Add(1)
 	go s.run() // Start the single, durable goroutine for this session.
+
+	return s, nil
+}
+
+// NewRestartSession resumes a relay session interrupted earlier on this server.
+//
+// Go's relay is store-and-forward: it caches a session to {uuid}.log and only
+// flushes upstream after the client's ExitMessage, so the client was handed a
+// LOCAL log_id (base64(uuid)) and the upstream never saw the original session.
+// C's relay forwards the RestartMessage upstream, which cannot work here because
+// the upstream has no log to resume. Instead we resume LOCALLY: decode the uuid
+// from the client's log_id, reopen that still-cached file, and append the
+// resumed I/O so the upstream eventually receives one continuous session
+// (Accept + original I/O + resumed I/O + Exit). The RestartMessage itself is
+// consumed here and not cached/forwarded.
+//
+// resume_point is advisory here: any I/O cached past it (cached but not yet
+// flushed, then re-sent by the client) is appended, so the overlap region can
+// be duplicated — the same narrow window that exists whenever a client resends
+// already-stored I/O. If the cache file is gone (already flushed upstream, or
+// an unknown log_id) the session cannot be resumed and an error is returned.
+func NewRestartSession(ctx context.Context, restartMsg *pb.RestartMessage, cfg *config.RelayConfig, onDone func()) (*Session, error) {
+	decoded, err := base64.StdEncoding.DecodeString(restartMsg.GetLogId())
+	if err != nil || len(decoded) < 16 {
+		return nil, fmt.Errorf("relay restart: invalid log_id %q", restartMsg.GetLogId())
+	}
+	var sessionUUID uuid.UUID
+	copy(sessionUUID[:], decoded[:16])
+
+	cacheFileName := filepath.Join(cfg.RelayCacheDirectory, fmt.Sprintf("%s.log", sessionUUID.String()))
+	if info, statErr := os.Stat(cacheFileName); statErr != nil {
+		return nil, fmt.Errorf("relay restart: no cached session for log_id %s (cannot resume): %w", restartMsg.GetLogId(), statErr)
+	} else if info.IsDir() {
+		return nil, fmt.Errorf("relay restart: cache path %s is a directory", cacheFileName)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	s := &Session{
+		logID:          restartMsg.GetLogId(),
+		config:         cfg,
+		resume:         true,
+		fromClientChan: make(chan *pb.ClientMessage, 1000),
+		cacheFileName:  cacheFileName,
+		ctx:            ctx,
+		cancel:         cancel,
+		onDone:         onDone,
+	}
+	// Restore the single elapsed clock from resume_point so the synthesized
+	// commit points continue from where the interrupted session left off.
+	if rp := restartMsg.GetResumePoint(); rp != nil {
+		s.cumulativeDelay = durationFromTimeSpec(rp)
+	}
+	s.phase.Store(&phaseWriting)
+
+	s.wg.Add(1)
+	go s.run()
 
 	return s, nil
 }
@@ -246,10 +306,15 @@ func (s *Session) writeMessagesToCache() (completed bool) {
 		}
 	}()
 
-	// Write the essential AcceptMessage first to ensure the cache file is valid for flushing.
-	if err := writeProtoMessage(file, &pb.ClientMessage{Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: s.initialAcceptMsg}}); err != nil {
-		slog.Error("Failed to write initial accept message to cache", "log_id", s.logID, "error", err)
-		return
+	// Write the essential AcceptMessage first to ensure the cache file is valid
+	// for flushing. On a resume (restart), the existing cache file already opens
+	// with the original AcceptMessage, so we append the resumed I/O directly and
+	// the upstream ultimately receives one continuous session.
+	if !s.resume {
+		if err := writeProtoMessage(file, &pb.ClientMessage{Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: s.initialAcceptMsg}}); err != nil {
+			slog.Error("Failed to write initial accept message to cache", "log_id", s.logID, "error", err)
+			return
+		}
 	}
 
 	// Loop until the session context is cancelled (server shutdown), Close()

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -716,7 +716,11 @@ func connectToUpstream(ctx context.Context, cfg *config.RelayConfig) (protocol.P
 
 	slog.Debug("Dialing upstream", "host", cfg.UpstreamHost, "use_tls", cfg.UseTLS, "tls_skip_verify", cfg.TLSSkipVerify)
 	if cfg.UseTLS {
-		tlsConfig := &tls.Config{InsecureSkipVerify: cfg.TLSSkipVerify, MinVersion: tls.VersionTLS13}
+		minVer, verErr := config.TLSVersion(cfg.TLSMinVersion)
+		if verErr != nil {
+			return nil, fmt.Errorf("invalid relay tls_min_version: %w", verErr)
+		}
+		tlsConfig := &tls.Config{InsecureSkipVerify: cfg.TLSSkipVerify, MinVersion: minVer}
 		tlsDialer := tls.Dialer{NetDialer: dialer, Config: tlsConfig}
 		conn, err = tlsDialer.DialContext(ctx, "tcp", cfg.UpstreamHost)
 	} else {

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -655,7 +655,7 @@ func TestRelayRestartResumesCachedSession(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.RelayConfig{
 		RelayCacheDirectory:  tmpDir,
-		ReconnectAttempts:    0,             // do not attempt upstream; we inspect the cache
+		ReconnectAttempts:    0, // do not attempt upstream; we inspect the cache
 		MaxReconnectInterval: 100 * time.Millisecond,
 		ConnectTimeout:       time.Second,
 		UpstreamHost:         "127.0.0.1:0",

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -4,6 +4,7 @@ package relay
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -620,4 +621,109 @@ func TestRelayFinalCommitOnExit(t *testing.T) {
 
 	session.Close()
 	waitRelaySession(t, session, 2*time.Second)
+}
+
+// readCachedMessages reads all length-prefixed ClientMessages from a relay cache
+// file in order.
+func readCachedMessages(t *testing.T, path string) []*pb.ClientMessage {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open cache file: %v", err)
+	}
+	defer f.Close()
+	proc := protocol.NewProcessor(f, f)
+	var msgs []*pb.ClientMessage
+	for {
+		m, err := proc.ReadClientMessage()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("read cached message: %v", err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
+// TestRelayRestartResumesCachedSession verifies that a RestartMessage in relay
+// mode resumes the interrupted session's cache (appending the resumed I/O into
+// one continuous session) instead of being rejected. Go's batch relay cannot
+// forward the restart upstream as C does, so it continues locally.
+func TestRelayRestartResumesCachedSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.RelayConfig{
+		RelayCacheDirectory:  tmpDir,
+		ReconnectAttempts:    0,             // do not attempt upstream; we inspect the cache
+		MaxReconnectInterval: 100 * time.Millisecond,
+		ConnectTimeout:       time.Second,
+		UpstreamHost:         "127.0.0.1:0",
+	}
+	sessionUUID := uuid.MustParse("d4e5f6a7-b8c9-4d4e-bf5a-2b3c4d5e6f70")
+	acceptMsg := createTestAcceptMessage()
+
+	ttyout := func(s *Session, data string) {
+		t.Helper()
+		if _, err := s.HandleClientMessage(&pb.ClientMessage{
+			Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{Delay: &pb.TimeSpec{TvSec: 1}, Data: []byte(data)}},
+		}); err != nil {
+			t.Fatalf("ttyout %q: %v", data, err)
+		}
+	}
+
+	// Original session: Accept + one ttyout, then interrupted (Close, no Exit).
+	s1, err := NewSession(t.Context(), sessionUUID, acceptMsg, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := s1.HandleClientMessage(&pb.ClientMessage{Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: acceptMsg}}); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	ttyout(s1, "AAAAA")
+	s1.Close()
+	waitRelaySession(t, s1, 2*time.Second)
+
+	cacheFile := filepath.Join(tmpDir, sessionUUID.String()+".log")
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Fatalf("expected cache file to remain after interrupt: %v", err)
+	}
+
+	// Restart: resume by the relay-local log_id, send more I/O + Exit.
+	logID := base64.StdEncoding.EncodeToString(sessionUUID[:])
+	s2, err := NewRestartSession(t.Context(), &pb.RestartMessage{LogId: logID, ResumePoint: &pb.TimeSpec{TvSec: 1}}, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewRestartSession: %v", err)
+	}
+	ttyout(s2, "BBBBB")
+	if _, err := s2.HandleClientMessage(&pb.ClientMessage{Type: &pb.ClientMessage_ExitMsg{ExitMsg: &pb.ExitMessage{ExitValue: 0}}}); err != nil {
+		t.Fatalf("exit: %v", err)
+	}
+	s2.Close()
+	waitRelaySession(t, s2, 2*time.Second)
+
+	// The cache must now be one continuous session: Accept, AAAAA, BBBBB, Exit.
+	msgs := readCachedMessages(t, cacheFile)
+	if len(msgs) != 4 {
+		t.Fatalf("cache has %d messages, want 4 (Accept, 2x ttyout, Exit)", len(msgs))
+	}
+	if msgs[0].GetAcceptMsg() == nil {
+		t.Errorf("msg[0] = %T, want AcceptMessage", msgs[0].Type)
+	}
+	if b := msgs[1].GetTtyoutBuf(); b == nil || string(b.Data) != "AAAAA" {
+		t.Errorf("msg[1] = %v, want ttyout AAAAA", msgs[1])
+	}
+	if b := msgs[2].GetTtyoutBuf(); b == nil || string(b.Data) != "BBBBB" {
+		t.Errorf("msg[2] = %v, want ttyout BBBBB (resumed I/O must be appended)", msgs[2])
+	}
+	if msgs[3].GetExitMsg() == nil {
+		t.Errorf("msg[3] = %T, want ExitMessage", msgs[3].Type)
+	}
+
+	// A restart for an unknown/already-flushed log_id cannot resume locally.
+	goneUUID := uuid.New()
+	gone := base64.StdEncoding.EncodeToString(goneUUID[:])
+	if _, err := NewRestartSession(t.Context(), &pb.RestartMessage{LogId: gone}, cfg, nil); err == nil {
+		t.Error("expected error resuming a relay session with no cache file")
+	}
 }

--- a/internal/relay/session_test.go
+++ b/internal/relay/session_test.go
@@ -555,3 +555,69 @@ func readCachedPayloads(path string) (map[uint32]struct{}, error) {
 		out[binary.BigEndian.Uint32(data)] = struct{}{}
 	}
 }
+
+// TestRelayFinalCommitOnExit verifies the downstream client gets a FINAL
+// commit_point on Exit whose value is the cumulative clock summed across all
+// streams AND winsize/suspend — even though the upstream is flushed
+// asynchronously later. Without it a stock client stalls in CLOSING.
+func TestRelayFinalCommitOnExit(t *testing.T) {
+	tmpDir := t.TempDir()
+	relayCfg := &config.RelayConfig{
+		RelayCacheDirectory:  tmpDir,
+		ReconnectAttempts:    0,
+		MaxReconnectInterval: 100 * time.Millisecond,
+		ConnectTimeout:       time.Second,
+		UpstreamHost:         "127.0.0.1:0", // never connects; we only exercise HandleClientMessage
+	}
+
+	session, err := NewSession(t.Context(), uuid.New(), createTestAcceptMessage(), relayCfg, nil)
+	if err != nil {
+		t.Fatalf("NewSession() failed: %v", err)
+	}
+
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: createTestAcceptMessage()},
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(Accept) failed: %v", err)
+	}
+
+	// ttyout 1.1s -> first I/O event emits a commit point carrying the global total.
+	if resp, err := session.HandleClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{Delay: &pb.TimeSpec{TvSec: 1, TvNsec: 100000000}, Data: []byte("out")}},
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(ttyout) failed: %v", err)
+	} else if cp := resp.GetCommitPoint(); cp == nil || cp.TvSec != 1 || cp.TvNsec != 100000000 {
+		t.Fatalf("first commit_point = %v, want 1.1s", cp)
+	}
+
+	// winsize 0.4s and stdin 0.5s advance the same clock; neither emits a commit
+	// (winsize is non-I/O; stdin is within the throttle interval).
+	for _, m := range []*pb.ClientMessage{
+		{Type: &pb.ClientMessage_WinsizeEvent{WinsizeEvent: &pb.ChangeWindowSize{Delay: &pb.TimeSpec{TvNsec: 400000000}, Rows: 30, Cols: 90}}},
+		{Type: &pb.ClientMessage_StdinBuf{StdinBuf: &pb.IoBuffer{Delay: &pb.TimeSpec{TvNsec: 500000000}, Data: []byte("in")}}},
+	} {
+		if resp, err := session.HandleClientMessage(m); err != nil {
+			t.Fatalf("HandleClientMessage(%T) failed: %v", m.Type, err)
+		} else if resp != nil {
+			t.Errorf("expected no commit_point for %T, got %v", m.Type, resp)
+		}
+	}
+
+	// Exit -> FINAL commit_point = 1.1 + 0.4 + 0.5 = 2.0s.
+	resp, err := session.HandleClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_ExitMsg{ExitMsg: &pb.ExitMessage{ExitValue: 0}},
+	})
+	if err != nil {
+		t.Fatalf("HandleClientMessage(Exit) failed: %v", err)
+	}
+	cp := resp.GetCommitPoint()
+	if cp == nil {
+		t.Fatal("expected FINAL commit_point on Exit in relay mode; without it a stock client hangs in CLOSING")
+	}
+	if cp.TvSec != 2 || cp.TvNsec != 0 {
+		t.Errorf("final commit_point = %d.%09d, want 2.000000000", cp.TvSec, cp.TvNsec)
+	}
+
+	session.Close()
+	waitRelaySession(t, session, 2*time.Second)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,9 +92,14 @@ func (s *Server) Start() error {
 			s.closeListeners()
 			return fmt.Errorf("failed to load TLS key pair: %w", err)
 		}
+		minVer, err := config.TLSVersion(cfg.Server.TLSMinVersion)
+		if err != nil {
+			s.closeListeners()
+			return fmt.Errorf("invalid server tls_min_version: %w", err)
+		}
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS13,
+			MinVersion:   minVer,
 		}
 		tlsListener, err := tls.Listen("tcp", cfg.Server.ListenAddressTLS, tlsConfig)
 		if err != nil {

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -133,11 +133,85 @@ var seqMutexMapLock sync.RWMutex
 
 const alphanumericChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-// sanitizePathComponent removes forward slashes from user-controlled path values
-// to prevent path traversal attacks via escape sequence expansion.
-// Matches the behavior of strlcpy_no_slash() in C sudo_logsrvd.
+// sanitizePathComponent replaces forward slashes in user-controlled path values
+// with underscores, preventing path traversal via escape-sequence expansion
+// while matching C sudo_logsrvd's strlcpy_no_slash() (lib/iolog/iolog_path.c),
+// which maps '/' to '_'. This both blocks traversal and produces the same
+// on-disk component a C server would (e.g. a submituser "a/b" -> "a_b").
 func sanitizePathComponent(s string) string {
-	return strings.ReplaceAll(s, "/", "")
+	return strings.ReplaceAll(s, "/", "_")
+}
+
+// strftimeExpand expands C strftime-style "%X" date/time escapes against t,
+// matching the strftime pass C sudo applies to an iolog path after %{...}
+// expansion (lib/iolog/iolog_path.c). "%%" collapses to a literal "%". Only the
+// common atomic codes are supported; codes that would introduce a path
+// separator or control character (e.g. %D, %F, %T, %n, %t) and any unrecognized
+// code are copied through verbatim, so an unknown escape can never inject a "/"
+// into a path component.
+func strftimeExpand(s string, t time.Time) string {
+	if !strings.ContainsRune(s, '%') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] != '%' || i+1 >= len(s) {
+			b.WriteByte(s[i])
+			continue
+		}
+		i++
+		switch c := s[i]; c {
+		case '%':
+			b.WriteByte('%')
+		case 'Y':
+			b.WriteString(t.Format("2006"))
+		case 'y':
+			b.WriteString(t.Format("06"))
+		case 'C':
+			fmt.Fprintf(&b, "%02d", t.Year()/100)
+		case 'm':
+			b.WriteString(t.Format("01"))
+		case 'd':
+			b.WriteString(t.Format("02"))
+		case 'e':
+			fmt.Fprintf(&b, "%2d", t.Day())
+		case 'H':
+			b.WriteString(t.Format("15"))
+		case 'I':
+			b.WriteString(t.Format("03"))
+		case 'M':
+			b.WriteString(t.Format("04"))
+		case 'S':
+			b.WriteString(t.Format("05"))
+		case 'p':
+			b.WriteString(t.Format("PM"))
+		case 'A':
+			b.WriteString(t.Format("Monday"))
+		case 'a':
+			b.WriteString(t.Format("Mon"))
+		case 'B':
+			b.WriteString(t.Format("January"))
+		case 'b', 'h':
+			b.WriteString(t.Format("Jan"))
+		case 'j':
+			fmt.Fprintf(&b, "%03d", t.YearDay())
+		case 'u': // ISO weekday, 1=Mon .. 7=Sun
+			if wd := int(t.Weekday()); wd == 0 {
+				b.WriteByte('7')
+			} else {
+				b.WriteString(strconv.Itoa(wd))
+			}
+		case 'w': // weekday, 0=Sun .. 6=Sat
+			b.WriteString(strconv.Itoa(int(t.Weekday())))
+		default:
+			// Unknown / unsupported code: copy verbatim (never expands to a
+			// path separator), matching glibc's pass-through for unknown codes.
+			b.WriteByte('%')
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
 }
 
 // writeNewFile is a symlink- and clobber-safe replacement for os.WriteFile used
@@ -494,18 +568,25 @@ func buildSessionPath(sessionUUID uuid.UUID, cfg *config.LocalStorageConfig, acc
 	epochStr := strconv.FormatInt(now.Unix(), 10)
 
 	// Replacer for sudoers-style escape sequences.
-	// User-controlled values are sanitized to strip "/" characters,
+	// User-controlled values are sanitized ("/" -> "_") to prevent traversal,
 	// matching C sudo_logsrvd's strlcpy_no_slash() behavior.
+	runuser := sanitizePathComponent(infoMap["runuser"])
+	rungroup := sanitizePathComponent(infoMap["rungroup"])
 	replacer := strings.NewReplacer(
 		// User/Group escapes (sanitized — user-controlled)
 		"%{user}", sanitizePathComponent(infoMap["submituser"]),
 		"%{uid}", sanitizePathComponent(infoMap["submituid"]),
 		"%{group}", sanitizePathComponent(infoMap["submitgroup"]),
 		"%{gid}", sanitizePathComponent(infoMap["submitgid"]),
-		"%{runuser}", sanitizePathComponent(infoMap["runuser"]),
+		"%{runuser}", runuser,
 		"%{runuid}", sanitizePathComponent(infoMap["runuid"]),
-		"%{rungroup}", sanitizePathComponent(infoMap["rungroup"]),
+		"%{rungroup}", rungroup,
 		"%{rungid}", sanitizePathComponent(infoMap["rungid"]),
+		// Canonical sudo names for the run-as identity (lib/iolog/iolog_path.c:
+		// fill_runas_user / fill_runas_group). Aliased to the same values so a
+		// template copied from a C sudoers config expands identically.
+		"%{runas_user}", runuser,
+		"%{runas_group}", rungroup,
 		// Host/Command escapes (sanitized — user-controlled)
 		"%{hostname}", sanitizePathComponent(infoMap["submithost"]),
 		"%{command_path}", sanitizePathComponent(infoMap["command"]),
@@ -513,7 +594,7 @@ func buildSessionPath(sessionUUID uuid.UUID, cfg *config.LocalStorageConfig, acc
 		// Sequence and Random escapes (server-generated, safe)
 		"%{seq}", seq,
 		"%{rand}", randStr,
-		// Time/Date escapes (server-generated, safe)
+		// Time/Date escapes (server-generated, safe) — Go brace-style extensions
 		"%{year}", fmt.Sprintf("%04d", now.Year()),
 		"%{month}", fmt.Sprintf("%02d", now.Month()),
 		"%{day}", fmt.Sprintf("%02d", now.Day()),
@@ -523,12 +604,19 @@ func buildSessionPath(sessionUUID uuid.UUID, cfg *config.LocalStorageConfig, acc
 		"%{epoch}", epochStr,
 		// Path escapes
 		"%{LIVEDIR}", cfg.LogDirectory,
-		// Literal percent escape
-		"%%", "%",
+		// NOTE: literal "%%" and bare strftime "%X" codes are handled by
+		// strftimeExpand below (after brace expansion), matching C's model.
 	)
 
 	iologDir := replacer.Replace(cfg.IologDir)
 	iologFile := replacer.Replace(cfg.IologFile)
+
+	// After %{...} expansion, apply C-style strftime over the path for bare
+	// "%X" date/time codes and to collapse "%%" -> "%". C sudo runs strftime on
+	// the whole iolog path (lib/iolog/iolog_path.c), so a template using the
+	// standard sudo date escapes (e.g. "%Y-%m-%d") expands the same way here.
+	iologDir = strftimeExpand(iologDir, now)
+	iologFile = strftimeExpand(iologFile, now)
 
 	// Reject paths containing ".." to prevent directory traversal.
 	// This check must run before filepath.Join, which cleans the path and

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -663,16 +663,21 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 		return "", fmt.Errorf("could not sync sequence file: %w", err)
 	}
 
-	// Convert the number to a 6-character, zero-padded, base36 string
-	const base36 = "0123456789abcdefghijklmnopqrstuvwxyz"
-	seqStr := ""
+	// Convert the number to a 6-character, zero-padded base36 string using the
+	// UPPERCASE alphabet C sudo uses (lib/iolog/iolog_nextid.c:57), then split it
+	// into the XX/XX/XX directory hierarchy C's fill_seq emits
+	// (logsrvd/iolog_writer.c:469). sudoreplay resolves a session by building
+	// session_dir/%.2s/%.2s/%.2s from the 6-char id (sudoreplay.c:327), so the
+	// on-disk layout must use this split form, not a flat 6-char directory.
+	const base36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var raw [6]byte
 	val := nextSeq
-	for range 6 {
-		seqStr = string(base36[val%36]) + seqStr
+	for i := 5; i >= 0; i-- {
+		raw[i] = base36[val%36]
 		val /= 36
 	}
 
-	return seqStr, nil
+	return fmt.Sprintf("%c%c/%c%c/%c%c", raw[0], raw[1], raw[2], raw[3], raw[4], raw[5]), nil
 }
 
 // LogID returns the base64-encoded sudo log_id assigned when the session was

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -55,7 +55,13 @@ type Session struct {
 	gzipWriters     map[string]*gzip.Writer // Gzip writers for compressed streams
 	timingFile      *os.File
 	logJSONPath     string // path to log.json; writes go through writeFileAtomic
-	cumulativeDelay map[string]time.Duration
+	// cumulativeDelay is a SINGLE counter summed across every I/O, winsize, and
+	// suspend delay — mirroring C sudo_logsrvd's one closure->elapsed_time. Every
+	// commit_point (periodic and the final one on Exit) reports this value, which
+	// is exactly what the client compares against its own global elapsed time
+	// before leaving the CLOSING state. A per-stream value would never satisfy
+	// the client's committed==elapsed equality for multi-stream sessions.
+	cumulativeDelay time.Duration
 	logMeta         map[string]any
 	passwordFilter  *PasswordFilter // Password filtering for security
 	lastCommitTime  time.Time       // Tracks when last commit point was sent
@@ -227,7 +233,6 @@ func NewSession(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.
 		sessionDir:      sessionDir,
 		files:           make(map[string]*os.File),
 		gzipWriters:     make(map[string]*gzip.Writer),
-		cumulativeDelay: make(map[string]time.Duration),
 		logMeta:         make(map[string]any),
 	}
 
@@ -739,8 +744,14 @@ func (s *Session) HandleClientMessage(msg *pb.ClientMessage) (*pb.ServerMessage,
 	case *pb.ClientMessage_SuspendEvent:
 		return s.handleSuspend(event.SuspendEvent)
 	case *pb.ClientMessage_ExitMsg:
+		// Send a FINAL commit_point carrying the full cumulative elapsed time,
+		// matching C sudo_logsrvd's handle_exit (it schedules an immediate commit
+		// event before closing). The stock client enters CLOSING after Exit and
+		// blocks until it receives a commit_point where committed==elapsed; without
+		// this the client stalls log_server_timeout (default 30s) and warns.
+		final := s.commitPointMsg()
 		s.finalize(event.ExitMsg)
-		return nil, nil // No response needed for Exit
+		return final, nil
 	default:
 		slog.Warn("Local storage session received unhandled message type", "type", fmt.Sprintf("%T", event))
 		return nil, nil // Ignore unhandled
@@ -985,8 +996,7 @@ func (s *Session) writeIoEntry(streamName string, delay *pb.TimeSpec, data []byt
 	}
 
 	// Write timing info using integer format matching C sudo_logsrvd: "%d %lld.%09d %zu\n"
-	delayDur := time.Duration(delay.TvSec)*time.Second + time.Duration(delay.TvNsec)*time.Nanosecond
-	s.cumulativeDelay[streamName] += delayDur
+	s.cumulativeDelay += durationFromTimeSpec(delay)
 
 	timingRecord := fmt.Sprintf("%d %d.%09d %d\n",
 		streamInfo.marker,
@@ -1002,22 +1012,40 @@ func (s *Session) writeIoEntry(streamName string, delay *pb.TimeSpec, data []byt
 	// The first I/O event always sends one (zero-value lastCommitTime guarantees this).
 	if time.Since(s.lastCommitTime) >= commitPointInterval {
 		s.lastCommitTime = time.Now()
-		commitPoint := s.cumulativeDelay[streamName]
-		return &pb.ServerMessage{Type: &pb.ServerMessage_CommitPoint{
-			CommitPoint: &pb.TimeSpec{
-				TvSec:  int64(commitPoint.Seconds()),
-				TvNsec: int32(commitPoint.Nanoseconds() % 1e9),
-			},
-		}}, nil
+		return s.commitPointMsg(), nil
 	}
 
 	return nil, nil
+}
+
+// durationFromTimeSpec converts a protobuf TimeSpec delay into a time.Duration.
+func durationFromTimeSpec(ts *pb.TimeSpec) time.Duration {
+	return time.Duration(ts.GetTvSec())*time.Second + time.Duration(ts.GetTvNsec())*time.Nanosecond
+}
+
+// commitPointMsg builds a ServerMessage carrying the session's cumulative
+// elapsed time. The client compares this value against its own global elapsed
+// time; integer second/nanosecond split matches C's commit_point encoding.
+// Callers must hold fileMux (cumulativeDelay is mutated under it).
+func (s *Session) commitPointMsg() *pb.ServerMessage {
+	d := s.cumulativeDelay
+	return &pb.ServerMessage{Type: &pb.ServerMessage_CommitPoint{
+		CommitPoint: &pb.TimeSpec{
+			TvSec:  int64(d / time.Second),
+			TvNsec: int32(d % time.Second),
+		},
+	}}
 }
 
 func (s *Session) handleWinsize(event *pb.ChangeWindowSize) (*pb.ServerMessage, error) {
 	if event.Delay == nil {
 		return nil, fmt.Errorf("missing delay in ChangeWindowSize event")
 	}
+	// Advance the cumulative elapsed clock, matching C's update_elapsed_time on
+	// winsize events. The value is reported by the next periodic commit and by
+	// the final commit on Exit; winsize itself emits no commit point.
+	s.cumulativeDelay += durationFromTimeSpec(event.Delay)
+
 	timingRecord := fmt.Sprintf("%d %d.%09d %d %d\n", IO_EVENT_WINSIZE, event.Delay.TvSec, event.Delay.TvNsec, event.Rows, event.Cols)
 	slog.Debug("Writing winsize entry", "log_id", s.logID, "record", strings.TrimSpace(timingRecord))
 	if _, err := s.timingFile.WriteString(timingRecord); err != nil {
@@ -1035,6 +1063,10 @@ func (s *Session) handleSuspend(event *pb.CommandSuspend) (*pb.ServerMessage, er
 	if !validSuspendSignals[event.Signal] {
 		return nil, fmt.Errorf("invalid CommandSuspend signal: %q", event.Signal)
 	}
+
+	// Advance the cumulative elapsed clock, matching C's update_elapsed_time on
+	// suspend events, so the final commit on Exit includes suspend/resume gaps.
+	s.cumulativeDelay += durationFromTimeSpec(event.Delay)
 
 	// Sudo uses marker 7 for all suspend/resume events; signal name differentiates them
 	timingRecord := fmt.Sprintf("%d %d.%09d %s\n", IO_EVENT_SUSPEND, event.Delay.TvSec, event.Delay.TvNsec, event.Signal)
@@ -1232,14 +1264,11 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 		files[streamName] = f
 	}
 
-	// Restore cumulative delay from resume_point
-	cumulativeDelay := make(map[string]time.Duration)
+	// Restore the cumulative elapsed clock from resume_point so commit points
+	// after the restart continue from where the prior session left off.
+	var cumulativeDelay time.Duration
 	if resumePoint := restartMsg.GetResumePoint(); resumePoint != nil {
-		dur := time.Duration(resumePoint.TvSec)*time.Second + time.Duration(resumePoint.TvNsec)*time.Nanosecond
-		// Apply to all streams as a starting point
-		for streamName := range streamMap {
-			cumulativeDelay[streamName] = dur
-		}
+		cumulativeDelay = durationFromTimeSpec(resumePoint)
 	}
 
 	session := &Session{

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -1304,6 +1304,122 @@ func DecodeLogID(logID string) (uuid.UUID, string, error) {
 	return sessionUUID, relativePath, nil
 }
 
+// parseTimingDelay parses a "sec.nsec" timing delay field into a Duration.
+func parseTimingDelay(s string) (time.Duration, error) {
+	secStr, nsecStr, ok := strings.Cut(s, ".")
+	if !ok {
+		return 0, fmt.Errorf("missing decimal in delay %q", s)
+	}
+	sec, err := strconv.ParseInt(secStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad seconds in delay %q: %w", s, err)
+	}
+	// Written as %09d; pad short fields and use the first 9 digits defensively.
+	for len(nsecStr) < 9 {
+		nsecStr += "0"
+	}
+	nsec, err := strconv.ParseInt(nsecStr[:9], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad nanoseconds in delay %q: %w", s, err)
+	}
+	return time.Duration(sec)*time.Second + time.Duration(nsec)*time.Nanosecond, nil
+}
+
+// computeResumeOffsets replays the timing file to find the byte offset at which a
+// restart should resume so resent I/O OVERWRITES (not duplicates) everything
+// recorded after target. It mirrors C sudo's iolog_seekto: each record's delay
+// is accumulated and each stream's offset advanced by the record's byte count
+// until the cumulative elapsed time equals target. An exact match is required —
+// an overshoot or hitting EOF first means resume_point does not align with the
+// stored log (same condition C treats as an error), reported via the error so
+// the caller can fall back to append mode. A zero target resumes at the start.
+func computeResumeOffsets(timingPath string, target time.Duration) (int64, map[string]int64, error) {
+	streamOffsets := make(map[string]int64)
+	if target <= 0 {
+		return 0, streamOffsets, nil
+	}
+	data, err := os.ReadFile(timingPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("read timing file: %w", err)
+	}
+	markerToStream := map[int]string{
+		IO_EVENT_STDIN: "stdin", IO_EVENT_STDOUT: "stdout", IO_EVENT_STDERR: "stderr",
+		IO_EVENT_TTYIN: "ttyin", IO_EVENT_TTYOUT: "ttyout",
+	}
+
+	var elapsed time.Duration
+	var timingOffset int64
+	content := string(data)
+	for len(content) > 0 {
+		var line string
+		if nl := strings.IndexByte(content, '\n'); nl >= 0 {
+			line = content[:nl]
+			timingOffset += int64(nl + 1)
+			content = content[nl+1:]
+		} else {
+			line = content
+			timingOffset += int64(len(content))
+			content = ""
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0, nil, fmt.Errorf("malformed timing record %q", line)
+		}
+		marker, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return 0, nil, fmt.Errorf("bad timing marker %q: %w", fields[0], err)
+		}
+		delay, err := parseTimingDelay(fields[1])
+		if err != nil {
+			return 0, nil, err
+		}
+		elapsed += delay
+		if stream, isIO := markerToStream[marker]; isIO {
+			if len(fields) < 3 {
+				return 0, nil, fmt.Errorf("I/O timing record missing byte count: %q", line)
+			}
+			nbytes, err := strconv.ParseInt(fields[2], 10, 64)
+			if err != nil {
+				return 0, nil, fmt.Errorf("bad timing byte count %q: %w", fields[2], err)
+			}
+			streamOffsets[stream] += nbytes
+		}
+
+		if elapsed >= target {
+			if elapsed == target {
+				return timingOffset, streamOffsets, nil
+			}
+			return 0, nil, fmt.Errorf("resume_point %v overshoots stored timing (nearest boundary %v)", target, elapsed)
+		}
+	}
+	return 0, nil, fmt.Errorf("resume_point %v is beyond the end of the stored timing", target)
+}
+
+// openForRestart opens an existing session file for a restart. When seek is true
+// it truncates to off and positions the file there, so resumed I/O overwrites
+// the post-resume_point region (matching C's iolog_seekto read->write switch);
+// otherwise it opens in append mode. O_NOFOLLOW guards against a symlink swap
+// between finalize and restart.
+func openForRestart(path string, cfg *config.LocalStorageConfig, seek bool, off int64) (*os.File, error) {
+	if !seek {
+		return os.OpenFile(path, os.O_APPEND|os.O_WRONLY|syscall.O_NOFOLLOW, os.FileMode(cfg.FilePermissions))
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NOFOLLOW, os.FileMode(cfg.FilePermissions))
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Truncate(off); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("truncate to resume offset %d: %w", off, err)
+	}
+	if _, err := f.Seek(off, io.SeekStart); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("seek to resume offset %d: %w", off, err)
+	}
+	return f, nil
+}
+
 // NewRestartSession creates a session that resumes an existing log from a RestartMessage.
 func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageConfig) (*Session, error) {
 	sessionUUID, relativePath, err := DecodeLogID(restartMsg.GetLogId())
@@ -1359,9 +1475,26 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 		return nil, fmt.Errorf("restart not supported for compressed sessions")
 	}
 
-	// Open timing file in append mode. O_NOFOLLOW guards against an attacker
-	// swapping the timing file for a symlink between session finalize and restart.
-	timingFile, err := os.OpenFile(timingPath, os.O_APPEND|os.O_WRONLY|syscall.O_NOFOLLOW, os.FileMode(cfg.FilePermissions))
+	// Determine where to resume. C sudo's iolog_seekto (logsrvd/logsrv_util.c)
+	// replays the timing file to find the byte offset of resume_point in each
+	// stream, then OVERWRITES everything after it so resent I/O is not
+	// duplicated. We do the same: compute the offsets, then truncate+seek each
+	// file to its resume position. If resume_point does not align with the
+	// stored timing (overshoot or past EOF — e.g. an older client that sent
+	// per-stream commit points), fall back to append mode rather than failing
+	// the restart, logging a warning so the divergence is visible.
+	rp := restartMsg.GetResumePoint()
+	resumeDur := time.Duration(rp.GetTvSec())*time.Second + time.Duration(rp.GetTvNsec())*time.Nanosecond
+	timingOffset, streamOffsets, seekErr := computeResumeOffsets(timingPath, resumeDur)
+	useSeek := seekErr == nil
+	if seekErr != nil && resumeDur > 0 {
+		slog.Warn("Restart resume_point does not align with stored timing; appending instead of seeking (overlap region may be duplicated)",
+			"log_id", restartMsg.GetLogId(), "resume_point", resumeDur, "error", seekErr)
+	}
+
+	// Open the timing file positioned at the resume point (or append on fallback).
+	// O_NOFOLLOW guards against a symlink swap between finalize and restart.
+	timingFile, err := openForRestart(timingPath, cfg, useSeek, timingOffset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open timing file for restart: %w", err)
 	}
@@ -1377,15 +1510,16 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 		return nil, err
 	}
 
-	// Open existing I/O stream files in append mode.
-	// stdin/ttyin may not exist (on-demand creation), so only open files that are present.
+	// Open existing I/O stream files at their resume offset (or append on
+	// fallback). stdin/ttyin may not exist (on-demand creation), so only open
+	// files that are present; absent streams had no pre-resume data (offset 0).
 	files := make(map[string]*os.File)
 	for streamName, streamInfo := range streamMap {
 		filePath := filepath.Join(sessionDir, streamInfo.filename)
 		if _, statErr := os.Stat(filePath); os.IsNotExist(statErr) {
 			continue // On-demand file not yet created, will be created on first write
 		}
-		f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|syscall.O_NOFOLLOW, os.FileMode(cfg.FilePermissions))
+		f, err := openForRestart(filePath, cfg, useSeek, streamOffsets[streamName])
 		if err != nil {
 			// Clean up already opened files
 			for _, openFile := range files {
@@ -1400,8 +1534,8 @@ func NewRestartSession(restartMsg *pb.RestartMessage, cfg *config.LocalStorageCo
 	// Restore the cumulative elapsed clock from resume_point so commit points
 	// after the restart continue from where the prior session left off.
 	var cumulativeDelay time.Duration
-	if resumePoint := restartMsg.GetResumePoint(); resumePoint != nil {
-		cumulativeDelay = durationFromTimeSpec(resumePoint)
+	if resumeDur > 0 {
+		cumulativeDelay = resumeDur
 	}
 
 	session := &Session{

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -631,13 +631,15 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 	}
 
 	var currentSeq uint32
-	if stat.Size() >= 4 {
-		// Read the current sequence number
-		data := make([]byte, 4)
-		if _, err := f.ReadAt(data, 0); err != nil {
+	if size := stat.Size(); size > 0 {
+		raw := make([]byte, size)
+		if _, err := f.ReadAt(raw, 0); err != nil && err != io.EOF {
 			return "", fmt.Errorf("could not read sequence file: %w", err)
 		}
-		currentSeq = binary.BigEndian.Uint32(data)
+		currentSeq, err = parseSeqFile(raw)
+		if err != nil {
+			return "", fmt.Errorf("could not parse sequence file %s: %w", seqFile, err)
+		}
 	}
 
 	// Sequence numbers are encoded as 6-char base36 strings; 36^6 = 2,176,782,336
@@ -651,11 +653,17 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 	}
 	nextSeq := currentSeq + 1
 
-	// Write the new sequence number back to the file atomically
-	data := make([]byte, 4)
-	binary.BigEndian.PutUint32(data, nextSeq)
+	// Write the new sequence back as ASCII base36 text (6 chars + newline),
+	// matching C sudo's on-disk seq format (lib/iolog/iolog_nextid.c) so a C
+	// sudo_logsrvd and this server can interoperate on a shared iolog tree.
+	data := formatSeqFile(nextSeq)
 	if _, err := f.WriteAt(data, 0); err != nil {
 		return "", fmt.Errorf("could not write to sequence file: %w", err)
+	}
+	// Truncate to the exact ASCII length so migrating from the shorter legacy
+	// binary format leaves no stale trailing bytes.
+	if err := f.Truncate(int64(len(data))); err != nil {
+		return "", fmt.Errorf("could not truncate sequence file: %w", err)
 	}
 
 	// Ensure the write is flushed to disk
@@ -678,6 +686,38 @@ func getNextSeq(baseDir string, cfg *config.LocalStorageConfig) (string, error) 
 	}
 
 	return fmt.Sprintf("%c%c/%c%c/%c%c", raw[0], raw[1], raw[2], raw[3], raw[4], raw[5]), nil
+}
+
+// parseSeqFile decodes the on-disk sequence counter. The canonical format
+// (matching C sudo's iolog_nextid) is ASCII base36 text, optionally followed by
+// a newline/NUL. Older Go servers wrote a 4-byte big-endian uint32, so we fall
+// back to that when the bytes are not valid base36 text — this migrates the
+// counter in place on the next write instead of resetting it (a reset could
+// collide new sessions with existing on-disk session directories).
+func parseSeqFile(raw []byte) (uint32, error) {
+	if s := strings.Trim(string(raw), "\x00\n\r \t"); s != "" {
+		if v, err := strconv.ParseUint(s, 36, 32); err == nil {
+			return uint32(v), nil
+		}
+	}
+	if len(raw) >= 4 {
+		return binary.BigEndian.Uint32(raw[:4]), nil
+	}
+	return 0, fmt.Errorf("unrecognized sequence file content (%d bytes)", len(raw))
+}
+
+// formatSeqFile renders the sequence counter in C sudo's on-disk format: six
+// uppercase base36 digits followed by a newline (7 bytes total).
+func formatSeqFile(seq uint32) []byte {
+	const base36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	buf := make([]byte, 7)
+	v := seq
+	for i := 5; i >= 0; i-- {
+		buf[i] = base36[v%36]
+		v /= 36
+	}
+	buf[6] = '\n'
+	return buf
 }
 
 // LogID returns the base64-encoded sudo log_id assigned when the session was

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -47,14 +47,14 @@ const commitPointInterval = 10 * time.Second
 // methods (CheckOutput/FilterInput) which take passwordFilter.mu internally.
 // Acquiring locks in the reverse order will deadlock.
 type Session struct {
-	logID           string
-	sessionUUID     uuid.UUID
-	config          *config.LocalStorageConfig
-	sessionDir      string
-	files           map[string]*os.File
-	gzipWriters     map[string]*gzip.Writer // Gzip writers for compressed streams
-	timingFile      *os.File
-	logJSONPath     string // path to log.json; writes go through writeFileAtomic
+	logID       string
+	sessionUUID uuid.UUID
+	config      *config.LocalStorageConfig
+	sessionDir  string
+	files       map[string]*os.File
+	gzipWriters map[string]*gzip.Writer // Gzip writers for compressed streams
+	timingFile  *os.File
+	logJSONPath string // path to log.json; writes go through writeFileAtomic
 	// cumulativeDelay is a SINGLE counter summed across every I/O, winsize, and
 	// suspend delay — mirroring C sudo_logsrvd's one closure->elapsed_time. Every
 	// commit_point (periodic and the final one on Exit) reports this value, which
@@ -301,13 +301,13 @@ func NewSession(sessionUUID uuid.UUID, acceptMsg *pb.AcceptMessage, cfg *config.
 	}
 
 	session := &Session{
-		logID:           logID,
-		sessionUUID:     sessionUUID,
-		config:          cfg,
-		sessionDir:      sessionDir,
-		files:           make(map[string]*os.File),
-		gzipWriters:     make(map[string]*gzip.Writer),
-		logMeta:         make(map[string]any),
+		logID:       logID,
+		sessionUUID: sessionUUID,
+		config:      cfg,
+		sessionDir:  sessionDir,
+		files:       make(map[string]*os.File),
+		gzipWriters: make(map[string]*gzip.Writer),
+		logMeta:     make(map[string]any),
 	}
 
 	// Initialize password filter if enabled

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -67,8 +67,9 @@ func TestStorageSession(t *testing.T) {
 			t.Fatalf("HandleClientMessage(Accept) failed: %v", err)
 		}
 
-		// Check for correct server response (log_id should be base64-encoded)
-		expectedRelPath := "testuser/000001"
+		// Check for correct server response (log_id should be base64-encoded).
+		// %{seq}=1 expands to the C-compatible XX/XX/XX hierarchy "00/00/01".
+		expectedRelPath := "testuser/00/00/01"
 		idBytes := append(sessionUUID[:], []byte(expectedRelPath)...)
 		expectedLogID := base64.StdEncoding.EncodeToString(idBytes)
 		if serverResponse.GetLogId() != expectedLogID {
@@ -89,9 +90,9 @@ func TestStorageSession(t *testing.T) {
 			t.Fatalf("HandleClientMessage(ExitMsg) failed: %v", err)
 		}
 
-		// Verify that directories and files were created
-		// The sequence number will be "000001" since this test has its own tmpDir.
-		sessDir := filepath.Join(tmpDir, "testuser", "000001")
+		// Verify that directories and files were created.
+		// %{seq}=1 expands to "00/00/01" (C-compatible XX/XX/XX hierarchy).
+		sessDir := filepath.Join(tmpDir, "testuser", "00", "00", "01")
 		if _, err := os.Stat(sessDir); os.IsNotExist(err) {
 			t.Fatalf("Session directory '%s' was not created", sessDir)
 		}
@@ -157,7 +158,7 @@ func TestStorageSession(t *testing.T) {
 		}
 
 		// Verify ttyout file content
-		sessDir := filepath.Join(tmpDir, "testuser", "000001") // Sequence is 1 because of new tmpDir
+		sessDir := filepath.Join(tmpDir, "testuser", "00", "00", "01") // Sequence 1 -> "00/00/01"
 		ttyoutFile := filepath.Join(sessDir, "ttyout")
 		content, err := os.ReadFile(ttyoutFile)
 		if err != nil {
@@ -241,9 +242,19 @@ func TestStorageSession(t *testing.T) {
 			t.Errorf("Expected different sequence numbers, got same: %s", seq1)
 		}
 
-		// Test sequence file format (should be 6 characters, base36)
-		if len(seq1) != 6 {
-			t.Errorf("Expected sequence length 6, got %d", len(seq1))
+		// %{seq} expands to C's XX/XX/XX hierarchy: 6 uppercase base36 chars
+		// split by two slashes (length 8), so `sudoreplay <id>` resolves it.
+		for _, seq := range []string{seq1, seq2} {
+			if len(seq) != 8 || seq[2] != '/' || seq[5] != '/' {
+				t.Errorf("expected seq in XX/XX/XX form, got %q", seq)
+			}
+			if strings.ToUpper(seq) != seq {
+				t.Errorf("expected uppercase base36 seq (matching C), got %q", seq)
+			}
+		}
+		// First two sequences are 1 and 2 -> "00/00/01" and "00/00/02".
+		if seq1 != "00/00/01" || seq2 != "00/00/02" {
+			t.Errorf("expected seq1=00/00/01 seq2=00/00/02, got %q and %q", seq1, seq2)
 		}
 	})
 
@@ -1013,7 +1024,7 @@ func TestNewSessionLogIDSiblingPrefixPath(t *testing.T) {
 	}
 	defer session.Close()
 
-	expectedPath := filepath.Join(siblingPrefixDir, "testuser", "000001")
+	expectedPath := filepath.Join(siblingPrefixDir, "testuser", "00", "00", "01")
 	if session.sessionDir != expectedPath {
 		t.Fatalf("unexpected session dir: expected %q, got %q", expectedPath, session.sessionDir)
 	}

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -1807,3 +1807,101 @@ func TestIologEscapeParity(t *testing.T) {
 		t.Errorf("buildSessionPath()\n got  %q\n want %q\n(runas_* aliases, strftime %%Y-%%m-%%d, %%%% -> %%, and '/' -> '_')", got, want)
 	}
 }
+
+// TestRestartResumeSeek verifies that a restart seeks to resume_point and
+// OVERWRITES the post-resume data (matching C's iolog_seekto) when the point
+// aligns, and falls back to append (preserving the old, never-fail behavior)
+// when it does not.
+func TestRestartResumeSeek(t *testing.T) {
+	newCfg := func(dir string) *config.LocalStorageConfig {
+		return &config.LocalStorageConfig{
+			LogDirectory:    dir,
+			IologDir:        filepath.Join("%{LIVEDIR}", "%{user}"),
+			IologFile:       "%{seq}",
+			DirPermissions:  0o755,
+			FilePermissions: 0o644,
+			PasswordFilter:  false,
+		}
+	}
+	// writeTtyout sends one ttyout buffer with a 1s delay (so each record adds
+	// exactly 1s to the elapsed clock and len(data) bytes to the ttyout file).
+	writeTtyout := func(t *testing.T, s *Session, data string) {
+		t.Helper()
+		if _, err := s.HandleClientMessage(&pb.ClientMessage{
+			Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{
+				Delay: &pb.TimeSpec{TvSec: 1}, Data: []byte(data),
+			}},
+		}); err != nil {
+			t.Fatalf("write %q: %v", data, err)
+		}
+	}
+	// seed creates a session, writes "AAAAA" (t=1s) then "BBBBB" (t=2s), and
+	// closes it WITHOUT finalizing (so the timing file stays writable). Returns
+	// the log_id and session dir.
+	seed := func(t *testing.T, cfg *config.LocalStorageConfig) (string, string) {
+		t.Helper()
+		s, err := NewSession(uuid.New(), createTestAcceptMessage(), cfg)
+		if err != nil {
+			t.Fatalf("NewSession: %v", err)
+		}
+		if _, err := s.HandleClientMessage(&pb.ClientMessage{
+			Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: createTestAcceptMessage()},
+		}); err != nil {
+			t.Fatalf("accept: %v", err)
+		}
+		writeTtyout(t, s, "AAAAA")
+		writeTtyout(t, s, "BBBBB")
+		if err := s.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		return s.logID, s.sessionDir
+	}
+
+	t.Run("AlignedResumePointOverwrites", func(t *testing.T) {
+		cfg := newCfg(t.TempDir())
+		logID, sessDir := seed(t, cfg)
+
+		// Resume at 1s — exactly after the first ttyout record. The second
+		// ("BBBBB") must be overwritten by the resumed data, not duplicated.
+		s2, err := NewRestartSession(&pb.RestartMessage{LogId: logID, ResumePoint: &pb.TimeSpec{TvSec: 1}}, cfg)
+		if err != nil {
+			t.Fatalf("NewRestartSession: %v", err)
+		}
+		writeTtyout(t, s2, "CCCCC")
+		if err := s2.Close(); err != nil {
+			t.Fatalf("close restart: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(sessDir, "ttyout"))
+		if err != nil {
+			t.Fatalf("read ttyout: %v", err)
+		}
+		if string(got) != "AAAAACCCCC" {
+			t.Errorf("ttyout = %q, want %q (resume must overwrite the post-resume_point region)", got, "AAAAACCCCC")
+		}
+	})
+
+	t.Run("MisalignedResumePointFallsBackToAppend", func(t *testing.T) {
+		cfg := newCfg(t.TempDir())
+		logID, sessDir := seed(t, cfg)
+
+		// Resume at 1.5s — between record boundaries; cannot align, so the
+		// session must fall back to append (never fail) rather than seek.
+		s2, err := NewRestartSession(&pb.RestartMessage{LogId: logID, ResumePoint: &pb.TimeSpec{TvSec: 1, TvNsec: 500000000}}, cfg)
+		if err != nil {
+			t.Fatalf("NewRestartSession (misaligned should still succeed): %v", err)
+		}
+		writeTtyout(t, s2, "CCCCC")
+		if err := s2.Close(); err != nil {
+			t.Fatalf("close restart: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(sessDir, "ttyout"))
+		if err != nil {
+			t.Fatalf("read ttyout: %v", err)
+		}
+		if string(got) != "AAAAABBBBBCCCCC" {
+			t.Errorf("ttyout = %q, want %q (misaligned resume must append, preserving prior data)", got, "AAAAABBBBBCCCCC")
+		}
+	})
+}

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -1709,3 +1709,65 @@ func TestStorageSessionCommitPoints(t *testing.T) {
 		t.Errorf("final commit_point = %d.%09d, want 2.000000000 (sum of all stream/winsize/suspend delays)", cp.TvSec, cp.TvNsec)
 	}
 }
+
+// TestSeqFileFormat verifies the sequence counter is stored as C sudo's ASCII
+// base36 text (so a C sudo_logsrvd and this server can share an iolog tree),
+// that a C-written file is read correctly, and that a legacy binary counter is
+// migrated in place without resetting (which could collide session dirs).
+func TestSeqFileFormat(t *testing.T) {
+	cfg := &config.LocalStorageConfig{DirPermissions: 0o755, FilePermissions: 0o644}
+
+	t.Run("WritesAsciiBase36", func(t *testing.T) {
+		dir := t.TempDir()
+		seq, err := getNextSeq(dir, cfg)
+		if err != nil {
+			t.Fatalf("getNextSeq: %v", err)
+		}
+		// The returned %{seq} value is the XX/XX/XX hierarchy; the on-disk
+		// counter is the flat 6-char ASCII base36 form.
+		if seq != "00/00/01" {
+			t.Errorf("first seq = %q, want 00/00/01", seq)
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, "seq"))
+		if err != nil {
+			t.Fatalf("read seq file: %v", err)
+		}
+		if string(raw) != "000001\n" {
+			t.Errorf("seq file = %q, want %q (ASCII base36 + newline)", raw, "000001\n")
+		}
+	})
+
+	t.Run("ReadsCStyleAsciiFile", func(t *testing.T) {
+		dir := t.TempDir()
+		// C-style file at value 35 ("Z"); next should be 36 -> "000010".
+		if err := os.WriteFile(filepath.Join(dir, "seq"), []byte("00000Z\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		seq, err := getNextSeq(dir, cfg)
+		if err != nil {
+			t.Fatalf("getNextSeq: %v", err)
+		}
+		if seq != "00/00/10" {
+			t.Errorf("seq after 00000Z = %q, want 00/00/10", seq)
+		}
+	})
+
+	t.Run("MigratesLegacyBinaryWithoutReset", func(t *testing.T) {
+		dir := t.TempDir()
+		// Legacy 4-byte big-endian counter at value 5.
+		if err := os.WriteFile(filepath.Join(dir, "seq"), []byte{0, 0, 0, 5}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		seq, err := getNextSeq(dir, cfg)
+		if err != nil {
+			t.Fatalf("getNextSeq: %v", err)
+		}
+		if seq != "00/00/06" {
+			t.Errorf("seq after legacy binary 5 = %q, want 00/00/06 (counter must not reset)", seq)
+		}
+		raw, _ := os.ReadFile(filepath.Join(dir, "seq"))
+		if string(raw) != "000006\n" {
+			t.Errorf("migrated seq file = %q, want %q (now ASCII)", raw, "000006\n")
+		}
+	})
+}

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -1771,3 +1771,39 @@ func TestSeqFileFormat(t *testing.T) {
 		}
 	})
 }
+
+// TestIologEscapeParity covers the C-compatibility escape behaviors:
+//   - %{runas_user}/%{runas_group} aliases expand to the run-as identity,
+//   - strftime-style %Y/%m/%d and %% are expanded over the path,
+//   - a '/' in a user-controlled value becomes '_' (not stripped).
+func TestIologEscapeParity(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.LocalStorageConfig{
+		LogDirectory:    tmpDir,
+		IologDir:        "%{LIVEDIR}/%{runas_user}/%{runas_group}",
+		IologFile:       "%Y-%m-%d/%{user}-%%end",
+		DirPermissions:  0o755,
+		FilePermissions: 0o644,
+	}
+	acceptMsg := &pb.AcceptMessage{
+		SubmitTime: &pb.TimeSpec{TvSec: time.Now().Unix()},
+		InfoMsgs: []*pb.InfoMessage{
+			{Key: "submituser", Value: &pb.InfoMessage_Strval{Strval: "a/b"}}, // slash -> "_"
+			{Key: "runuser", Value: &pb.InfoMessage_Strval{Strval: "root"}},
+			{Key: "rungroup", Value: &pb.InfoMessage_Strval{Strval: "wheel"}},
+			{Key: "command", Value: &pb.InfoMessage_Strval{Strval: "/bin/ls"}},
+		},
+	}
+
+	got, err := buildSessionPath(uuid.New(), cfg, acceptMsg)
+	if err != nil {
+		t.Fatalf("buildSessionPath() failed: %v", err)
+	}
+
+	now := time.Now()
+	date := fmt.Sprintf("%04d-%02d-%02d", now.Year(), int(now.Month()), now.Day())
+	want := filepath.Join(tmpDir, "root", "wheel", date, "a_b-%end")
+	if got != want {
+		t.Errorf("buildSessionPath()\n got  %q\n want %q\n(runas_* aliases, strftime %%Y-%%m-%%d, %%%% -> %%, and '/' -> '_')", got, want)
+	}
+}

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -1621,3 +1621,80 @@ func TestBuildSessionPathRejectsDotDotAfterExpansion(t *testing.T) {
 		t.Fatalf("expected path traversal error, got: %v", err)
 	}
 }
+
+// TestStorageSessionCommitPoints verifies the commit_point handshake that lets a
+// stock sudo client complete its CLOSING state:
+//   - the cumulative clock is a single value summed across ALL streams plus
+//     winsize and suspend (not per-stream), and
+//   - ExitMessage returns a FINAL commit_point equal to that total.
+//
+// Without both, a real client stalls log_server_timeout (default 30s) at the end
+// of every multi-stream I/O session and warns "lost connection to log server".
+func TestStorageSessionCommitPoints(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageCfg := &config.LocalStorageConfig{
+		LogDirectory:    tmpDir,
+		IologDir:        filepath.Join("%{LIVEDIR}", "%{user}"),
+		IologFile:       "%{seq}",
+		DirPermissions:  0755,
+		FilePermissions: 0644,
+	}
+
+	session, err := NewSession(uuid.New(), createTestAcceptMessage(), storageCfg)
+	if err != nil {
+		t.Fatalf("NewSession() failed: %v", err)
+	}
+	defer session.Close()
+
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: createTestAcceptMessage()},
+	}); err != nil {
+		t.Fatalf("HandleClientMessage(Accept) failed: %v", err)
+	}
+
+	// First I/O event always emits a commit point (zero-value lastCommitTime),
+	// and it must carry the GLOBAL cumulative value — here just the ttyout delay.
+	resp, err := session.HandleClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_TtyoutBuf{TtyoutBuf: &pb.IoBuffer{
+			Delay: &pb.TimeSpec{TvSec: 1, TvNsec: 100000000}, Data: []byte("out"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("HandleClientMessage(ttyout) failed: %v", err)
+	}
+	if cp := resp.GetCommitPoint(); cp == nil {
+		t.Fatal("expected commit_point on first I/O event")
+	} else if cp.TvSec != 1 || cp.TvNsec != 100000000 {
+		t.Errorf("first commit_point = %d.%09d, want 1.100000000", cp.TvSec, cp.TvNsec)
+	}
+
+	// A second stream, plus winsize and suspend — all advance the SAME clock and
+	// (being within the throttle interval / non-I/O) emit no commit point.
+	for _, m := range []*pb.ClientMessage{
+		{Type: &pb.ClientMessage_StdinBuf{StdinBuf: &pb.IoBuffer{Delay: &pb.TimeSpec{TvNsec: 200000000}, Data: []byte("in")}}},
+		{Type: &pb.ClientMessage_WinsizeEvent{WinsizeEvent: &pb.ChangeWindowSize{Delay: &pb.TimeSpec{TvNsec: 300000000}, Rows: 40, Cols: 100}}},
+		{Type: &pb.ClientMessage_SuspendEvent{SuspendEvent: &pb.CommandSuspend{Delay: &pb.TimeSpec{TvNsec: 400000000}, Signal: "TSTP"}}},
+	} {
+		if r, err := session.HandleClientMessage(m); err != nil {
+			t.Fatalf("HandleClientMessage(%T) failed: %v", m.Type, err)
+		} else if r != nil {
+			t.Errorf("expected no commit_point for %T, got %v", m.Type, r)
+		}
+	}
+
+	// Exit must return a FINAL commit_point equal to the sum of every delay:
+	// 1.1 + 0.2 + 0.3 + 0.4 = 2.0s exactly.
+	resp, err = session.HandleClientMessage(&pb.ClientMessage{
+		Type: &pb.ClientMessage_ExitMsg{ExitMsg: &pb.ExitMessage{ExitValue: 0}},
+	})
+	if err != nil {
+		t.Fatalf("HandleClientMessage(Exit) failed: %v", err)
+	}
+	cp := resp.GetCommitPoint()
+	if cp == nil {
+		t.Fatal("expected FINAL commit_point on Exit; without it a stock client hangs in CLOSING")
+	}
+	if cp.TvSec != 2 || cp.TvNsec != 0 {
+		t.Errorf("final commit_point = %d.%09d, want 2.000000000 (sum of all stream/winsize/suspend delays)", cp.TvSec, cp.TvNsec)
+	}
+}


### PR DESCRIPTION
## Why

A deep audit of `sudosrv-go` against the reference C `sudo_logsrvd` (sudo **1.9.18**) found the proto, length-prefix framing, and on-disk iolog format are sound, but several **behavioral** surfaces diverged enough to break a stock sudo client or `sudoreplay`. Most critically, the server never completed the commit-point close handshake, so every multi-stream I/O session stalled the client for `log_server_timeout` (default 30s) at teardown and logged *"lost connection to log server"*.

This PR stacks 9 independently-reviewed fixes (one commit each) closing every critical/high/medium gap from the audit. Only low-severity cosmetic divergences remain.

## What

**🔴 Critical — commit-point handshake** (`16fa3ef`)
- Send a FINAL `commit_point` on `ExitMessage`, and make the value a single cumulative clock summed across **all** streams + winsize + suspend (was per-stream), matching C's `closure->elapsed_time`. The stock client (and `sudo_sendlog`) block in `CLOSING` until `committed == elapsed`; without this they stall/warn on every multi-stream session. Applied to both local and relay sessions.

**🟠 High**
- **Rate limit → back-pressure** (`732e455`): block until a token refills instead of sending an error and closing the connection. C has no app-level limit; a burst of `ttyout` (verbose build, `yes`, `cat`) no longer severs a legitimate session.
- **idle_timeout opt-out** (`299fd42`): a non-positive `idle_timeout` (e.g. `-1s`) disables the per-message read deadline, matching C's NULL read timeout so a long-idle interactive shell isn't disconnected. Default 10m unchanged.
- **`%{seq}` layout** (`67f91b5`): expand to C's uppercase `XX/XX/XX` hierarchy so `sudoreplay <id>` (which builds `session_dir/%.2s/%.2s/%.2s`) resolves Go-written sessions.
- **Configurable TLS floor** (`80a147d`): add `tls_min_version` under `server:` and `relay:` (default **1.3**, opt-in **1.2** for legacy peers). The management API stays pinned to 1.3. Default posture is unchanged and secure.

**🟡 Medium**
- **iolog escape parity** (`c6b8747`): add `%{runas_user}`/`%{runas_group}`, support strftime `%Y/%m/%d/...` over the path, and map `/`→`_` in user values (was stripped) — so a template copied from a C sudoers config expands identically.
- **seq file format** (`210694b`): store the sequence counter as C's ASCII base36 text (was binary uint32) for shared C/Go iolog trees, with in-place migration of an existing binary counter (no reset → no dir collision).
- **Restart resume seek** (`4308154`): on restart, truncate+seek each stream/timing file to `resume_point` (mirrors `iolog_seekto`) so resent I/O overwrites instead of duplicating; falls back to append (never hard-fails) on a misaligned point.
- **Relay-mode restart** (`1a92da4`): resume an interrupted relayed session locally by appending to its still-cached file, instead of rejecting the `RestartMessage`.

`ce3591c` is pure gofmt (alignment shifts from the stacked changes).

## Compatibility notes / deliberate deviations

- **Relay restart** cannot replicate C's "forward the RestartMessage upstream": Go's store-and-forward relay hands the client a relay-local `log_id` and the upstream never saw the original session. The Go-native equivalent resumes the cache locally so the upstream still receives one continuous session. `resume_point` is advisory there (narrow duplicate window if the client re-sends already-cached I/O).
- Two pre-existing non-gofmt test files untouched by these fixes were intentionally left as-is.

## Testing

- `go build ./...` clean; `go vet ./...` clean.
- `go test -race -timeout 90s ./...` — all packages pass.
- Each fix ships a focused regression test (final/global commit_point, rate-limit back-pressure + ctx cancel, idle-timeout opt-out, `XX/XX/XX` seq, escape parity, seq-file ASCII + legacy migration, restart seek-overwrite vs append fallback, relay restart resume).

## Reference

Audited against `sudo 1.9.18` (`logsrvd/`, `lib/iolog/`, `lib/logsrv/`, `plugins/sudoers/log_client.c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)