### PR TITLE
Sanitize log summary fields and tighten relay cache permissions

### DIFF
--- a/cmd/sudosrv/main.go
+++ b/cmd/sudosrv/main.go
@@ -221,8 +221,16 @@ func initializeRelayMode(cfg *config.Config) error {
 			"upstream_host", cfg.Relay.UpstreamHost)
 	}
 
-	if err := os.MkdirAll(cfg.Relay.RelayCacheDirectory, 0750); err != nil {
+	// 0700 matches relay.NewSession: cache files carry raw sudo I/O (keystrokes,
+	// sometimes passwords — the storage password filter does not apply to the
+	// relay cache writer), so group/other must not even traverse the directory.
+	// MkdirAll does not chmod a pre-existing directory, so enforce the mode
+	// explicitly to repair directories created by older releases (0750).
+	if err := os.MkdirAll(cfg.Relay.RelayCacheDirectory, 0700); err != nil {
 		return fmt.Errorf("failed to create relay cache directory: %w", err)
+	}
+	if err := os.Chmod(cfg.Relay.RelayCacheDirectory, 0700); err != nil {
+		return fmt.Errorf("failed to tighten relay cache directory permissions: %w", err)
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -254,8 +255,35 @@ func Validate(cfg *Config) error {
 		if err := validateAuthTokenFile(cfg.API.AuthTokenFile); err != nil {
 			return err
 		}
+		// Plaintext HTTP is acceptable only for loopback deployments: every
+		// request carries the static bearer token, so serving it on a routable
+		// interface without TLS exposes the credential to the network. Warn
+		// rather than refuse so existing trusted-network deployments keep
+		// working, but make the exposure unmissable in the startup log.
+		if cfg.API.TLSCertFile == "" && !isLoopbackListenAddress(cfg.API.ListenAddress) {
+			slog.Warn("INSECURE: api.listen_address is not loopback and api TLS is not configured — "+
+				"the bearer token will traverse the network in cleartext. "+
+				"Configure api.tls_cert_file/api.tls_key_file or bind to 127.0.0.1.",
+				"listen_address", cfg.API.ListenAddress)
+		}
 	}
 	return nil
+}
+
+// isLoopbackListenAddress reports whether a listen address string is bound to
+// a loopback interface. An empty host (":8080"), a wildcard address, or an
+// unparsable host is treated as NOT loopback, so the caller errs on the side
+// of warning.
+func isLoopbackListenAddress(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // validateAuthTokenFile enforces the security preconditions documented for the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -743,3 +743,25 @@ func TestTLSMinVersionConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestIsLoopbackListenAddress(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:8888", true},
+		{"localhost:8888", true},
+		{"[::1]:8888", true},
+		{"0.0.0.0:8888", false},
+		{"[::]:8888", false},
+		{":8888", false},
+		{"10.0.0.5:8888", false},
+		{"example.com:8888", false},
+		{"not-an-address", false},
+	}
+	for _, tt := range tests {
+		if got := isLoopbackListenAddress(tt.addr); got != tt.want {
+			t.Errorf("isLoopbackListenAddress(%q) = %v, want %v", tt.addr, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/session.go
+++ b/internal/storage/session.go
@@ -142,6 +142,25 @@ func sanitizePathComponent(s string) string {
 	return strings.ReplaceAll(s, "/", "_")
 }
 
+// sanitizeLogSummaryField makes a client-supplied value safe for the plaintext
+// `log` summary file, whose first line is colon-delimited and whose records are
+// newline-delimited. Control characters (including CR/LF) are replaced with '?'
+// so a hostile client cannot split a record or forge additional ones, and ':'
+// is replaced with '_' in colon-delimited fields so field boundaries cannot be
+// shifted. log.json is unaffected — JSON encoding already escapes these.
+func sanitizeLogSummaryField(s string, colonDelimited bool) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case colonDelimited && r == ':':
+			return '_'
+		case r < 0x20 || r == 0x7f:
+			return '?'
+		default:
+			return r
+		}
+	}, s)
+}
+
 // strftimeExpand expands C strftime-style "%X" date/time escapes against t,
 // matching the strftime pass C sudo applies to an iolog path after %{...}
 // expansion (lib/iolog/iolog_path.c). "%%" collapses to a literal "%". Only the
@@ -963,14 +982,14 @@ func (s *Session) initialize(acceptMsg *pb.AcceptMessage) (retErr error) {
 	logSummaryPath := filepath.Join(s.sessionDir, "log")
 	summaryLine := fmt.Sprintf("%d:%s:%s:%s:%s:%s:%s\n%s\n%s\n",
 		submitTime.Unix(),
-		infoMap["submituser"],
-		infoMap["runuser"],
-		infoMap["rungroup"],
-		infoMap["ttyname"],
-		infoMap["lines"],
-		infoMap["columns"],
-		infoMap["submitcwd"],
-		infoMap["command"],
+		sanitizeLogSummaryField(infoMap["submituser"], true),
+		sanitizeLogSummaryField(infoMap["runuser"], true),
+		sanitizeLogSummaryField(infoMap["rungroup"], true),
+		sanitizeLogSummaryField(infoMap["ttyname"], true),
+		sanitizeLogSummaryField(infoMap["lines"], true),
+		sanitizeLogSummaryField(infoMap["columns"], true),
+		sanitizeLogSummaryField(infoMap["submitcwd"], false),
+		sanitizeLogSummaryField(infoMap["command"], false),
 	)
 	if err := writeNewFile(logSummaryPath, []byte(summaryLine), os.FileMode(s.config.FilePermissions)); err != nil {
 		return fmt.Errorf("failed to create 'log' summary file: %w", err)

--- a/internal/storage/session_test.go
+++ b/internal/storage/session_test.go
@@ -1905,3 +1905,78 @@ func TestRestartResumeSeek(t *testing.T) {
 		}
 	})
 }
+
+func TestSanitizeLogSummaryField(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             string
+		colonDelimited bool
+		want           string
+	}{
+		{"CleanPassthrough", "alice", true, "alice"},
+		{"ColonReplacedWhenDelimited", "evil:root", true, "evil_root"},
+		{"ColonKeptWhenNotDelimited", "/usr/bin/foo:bar", false, "/usr/bin/foo:bar"},
+		{"NewlineReplaced", "user\nroot:root:tty:1:1\nforged", true, "user?root_root_tty_1_1?forged"},
+		{"CarriageReturnAndDELReplaced", "a\rb\x7fc", false, "a?b?c"},
+		{"TabAndEscapeReplaced", "a\tb\x1b[2Jc", false, "a?b?[2Jc"},
+		{"UTF8Preserved", "пароль密码", true, "пароль密码"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeLogSummaryField(tt.in, tt.colonDelimited); got != tt.want {
+				t.Errorf("sanitizeLogSummaryField(%q, %v) = %q, want %q", tt.in, tt.colonDelimited, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLogSummaryFileInjection verifies end-to-end that a hostile client cannot
+// split or forge records in the plaintext `log` summary file via control
+// characters or colons embedded in AcceptMessage info fields.
+func TestLogSummaryFileInjection(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.LocalStorageConfig{
+		LogDirectory:    tmpDir,
+		DirPermissions:  0755,
+		FilePermissions: 0644,
+	}
+
+	acceptMsg := &pb.AcceptMessage{
+		SubmitTime:   &pb.TimeSpec{TvSec: 1700000000},
+		ExpectIobufs: true,
+		InfoMsgs: []*pb.InfoMessage{
+			{Key: "submituser", Value: &pb.InfoMessage_Strval{Strval: "alice\nroot:root:root:tty9:1:1"}},
+			{Key: "submithost", Value: &pb.InfoMessage_Strval{Strval: "host"}},
+			{Key: "runuser", Value: &pb.InfoMessage_Strval{Strval: "root:extra"}},
+			{Key: "command", Value: &pb.InfoMessage_Strval{Strval: "/bin/evil\n/bin/innocent"}},
+		},
+	}
+
+	sessionUUID := uuid.New()
+	session, err := NewSession(sessionUUID, acceptMsg, cfg)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := session.HandleClientMessage(&pb.ClientMessage{Type: &pb.ClientMessage_AcceptMsg{AcceptMsg: acceptMsg}}); err != nil {
+		t.Fatalf("HandleClientMessage(Accept): %v", err)
+	}
+	defer session.Close()
+
+	data, err := os.ReadFile(filepath.Join(session.sessionDir, "log"))
+	if err != nil {
+		t.Fatalf("read log summary: %v", err)
+	}
+	content := string(data)
+
+	// The format is exactly 3 lines: header, cwd, command. Injected newlines
+	// must not add more.
+	if lines := strings.Split(strings.TrimRight(content, "\n"), "\n"); len(lines) != 3 {
+		t.Errorf("log summary has %d lines, want 3 (newline injection not neutralized):\n%s", len(lines), content)
+	}
+	if strings.Contains(content, "root:root:root") {
+		t.Errorf("forged colon-delimited fields survived sanitization:\n%s", content)
+	}
+	if strings.Contains(content, "\n/bin/innocent") {
+		t.Errorf("newline in command field survived sanitization:\n%s", content)
+	}
+}


### PR DESCRIPTION
This PR addresses security issues in log file handling and relay cache directory permissions.

## Summary
Adds input sanitization for the plaintext `log` summary file to prevent log injection attacks, improves API TLS configuration validation with warnings for insecure deployments, and tightens relay cache directory permissions to prevent unauthorized access to sensitive I/O data.

## Key Changes

- **Log Summary Sanitization**: Introduces `sanitizeLogSummaryField()` function that:
  - Replaces control characters (CR, LF, ESC, DEL, etc.) with `?` to prevent record splitting
  - Replaces colons with underscores in colon-delimited fields to prevent field boundary shifts
  - Preserves UTF-8 characters for internationalization
  - Applied to all user-supplied fields in the `log` summary file (submituser, runuser, rungroup, ttyname, lines, columns, submitcwd, command)

- **API TLS Configuration Validation**: Adds `isLoopbackListenAddress()` helper that:
  - Detects when API is configured for plaintext HTTP on non-loopback interfaces
  - Emits a warning log message (rather than failing) to maintain backward compatibility with trusted-network deployments
  - Warns that bearer tokens will traverse the network in cleartext

- **Relay Cache Directory Permissions**: Tightens relay cache directory from 0750 to 0700:
  - Prevents group/other access to cached I/O data (which may contain keystrokes, passwords, etc.)
  - Explicitly enforces mode on existing directories to repair those created by older releases
  - Includes detailed comments explaining the security rationale

## Testing
Comprehensive test coverage added:
- `TestSanitizeLogSummaryField`: Unit tests for sanitization logic with various control characters and UTF-8
- `TestLogSummaryFileInjection`: End-to-end test verifying hostile clients cannot forge log records
- `TestIsLoopbackListenAddress`: Tests for loopback address detection with various formats

https://claude.ai/code/session_01TPy7HqGzez6JE8tzJarcpB